### PR TITLE
Keep preloaded images in memory

### DIFF
--- a/docs/markdown_docs/core_library/jspsych-pluginAPI.md
+++ b/docs/markdown_docs/core_library/jspsych-pluginAPI.md
@@ -177,6 +177,39 @@ source.start(startTime);
 ```
 
 ---
+## jsPsych.pluginAPI.getImageFromCache
+
+```
+jsPsych.pluginAPI.getAudioBuffer(url)
+```
+
+### Parameters
+
+Parameter | Type | Description
+----------|------|------------
+url | string | The URL to the image file that was preloaded.
+
+### Return value
+
+Returns an `HTMLImageElement`, which can be added to the dom. Returns `undefined`, if the file was not cached.
+
+### Description
+
+Gets an image DOM element that holds the preloaded image. The file must be preloaded with `preloadImages` or the automatic preload (`autoPreload`).
+
+### Examples
+
+```javascript
+// this code in single-stim
+display_element.append($('<img>', {
+  src: trial.stimulus,
+  id: 'jspsych-single-stim-stimulus'
+}));
+// could be replaced with
+display_element.append($(jsPsych.pluginAPI.getImageFromCache(trial.stimulus)).attr('id', 'jspsych-single-stim-stimulus'));
+```
+
+---
 ## jsPsych.pluginAPI.getKeyboardResponse
 
 ```

--- a/jspsych.js
+++ b/jspsych.js
@@ -1870,6 +1870,14 @@ jsPsych.pluginAPI = (function() {
     }
 
   }
+  
+  // images //
+
+  var image_cache = {};
+
+  module.getImageFromCache = function(url) {
+    return image_cache[url];
+  }
 
   module.preloadImages = function(images, callback_complete, callback_load) {
 
@@ -1905,6 +1913,9 @@ jsPsych.pluginAPI = (function() {
       }
 
       img.src = images[i];
+      
+      // put image element in cache
+      image_cache[images[i]] = img;
     }
   };
 


### PR DESCRIPTION
Preloaded images are not always cached - depending on the server settings - and are sometimes reloaded during the experiment. Getting the server settings right can sometimes be quite difficult. Keeping the images in memory during the experiment, will make sure they are not reloaded from the server.

Additionally plugins can use the new function `jsPsych.pluginAPI.getImage(url)` to get an IMG element from the cache. This is optional and could save memory in total. The caching works without using this function as well.
