### PR TITLE
added event handler to video plugin to end trial when a stop time is specified

### DIFF
--- a/plugins/jspsych-video.js
+++ b/plugins/jspsych-video.js
@@ -115,6 +115,16 @@ jsPsych.plugins.video = (function() {
       end_trial();
     }
 
+    // event handler to set timeout to end trial if video is stopped
+    display_element.querySelector('#jspsych-video-player').onplay = function(){
+      if(trial.stop != false){
+        if(trial.start == false){
+          trial.start = 0;
+        }
+        jsPsych.pluginAPI.setTimeout(end_trial, (trial.stop-trial.start)*1000);
+      }
+    }
+
     // function to end trial when it is time
     var end_trial = function() {
 


### PR DESCRIPTION
This PR fixes a bug in the video plugin where the trial does not end if a video stop time is specified.  This is because the plugin is looking for the `onended` event handler to send the trial, but that never happens if the video is stopped premature to its end.  This code sets a timeout for the duration of `stop-start`:

```
    // event handler to set timeout to end trial if video is stopped
    display_element.querySelector('#jspsych-video-player').onplay = function(){
      if(trial.stop != false){
        if(trial.start == false){
          trial.start = 0;
        }
        jsPsych.pluginAPI.setTimeout(end_trial, (trial.stop-trial.start)*1000);
      }
    }
```