### PR TITLE
Make jspsych an exportable module

### DIFF
--- a/jspsych.js
+++ b/jspsych.js
@@ -5,7 +5,7 @@
  * documentation: docs.jspsych.org
  *
  **/
-window.jsPsych = (function() {
+var jsPsych = (function() {
 
   var core = {};
 
@@ -2413,3 +2413,13 @@ if (!Array.isArray) {
     return Object.prototype.toString.call(arg) === '[object Array]';
   };
 }
+
+(function (root, factory) {
+  if(typeof define === "function" && define.amd) {
+     define([], factory);
+  } else if(typeof module === "object" && module.exports) {
+     module.exports = factory;
+  } else {
+     root.jsPsych = factory;
+  }
+}(this, jsPsych));


### PR DESCRIPTION
I have been working with some friends to make jspsych react-compatible (cf. [teonbrooks/jspsych-react](https://github.com/teonbrooks/jspsych-react/)).

the purpose of this pr is to make jspsych into an exportable module that supports [UMD](https://github.com/umdjs/umd). I've tested this out in both the html and as an import requirement and that both work.

This will allow the same workflow as before and extend it to those who want to use jspsych as package dependency.
