### PR TITLE
Add a parameter for getting a word instead of a function

### DIFF
--- a/examples/lexical-decision.html
+++ b/examples/lexical-decision.html
@@ -79,7 +79,7 @@
       },
       {
         type: 'html-keyboard-response',
-        stimulus: function(){ return "<p class='stimulus'>"+jsPsych.timelineVariable('word')+"</p>"; },
+        stimulus: function(){ return "<p class='stimulus'>"+jsPsych.timelineVariable('word', true)+"</p>"; },
         choices: ['y','n'],
         post_trial_gap: 500,
         data: function(){


### PR DESCRIPTION
When I run the sample, the js code is shown instead of a word.
Please see below.
<img width="826" alt="js_code_is_shown" src="https://user-images.githubusercontent.com/2550094/36712933-868dfa04-1bce-11e8-9ba7-caebaefd39dd.PNG">

To fix this, I added a parameter to jsPsych.timelineVariable executing.
