### PR TITLE
Fix #532 to allow script on external-html pages to be executed

### DIFF
--- a/plugins/jspsych-external-html.js
+++ b/plugins/jspsych-external-html.js
@@ -44,6 +44,14 @@ jsPsych.plugins['external-html'] = (function() {
         default: false,
         description: 'Refresh page.'
       }
+      // if execute_Script == true, then all javascript code on the external page
+      // will be executed in the plugin site within your jsPsych test
+      execute_Script: {
+        type: jsPsych.plugins.parameterType.BOOL,
+        pretty_name: 'Execute scripts',
+        default: false,
+        description: 'If true, JS scripts on the external html file will be executed.'
+      }
     }
   }
 
@@ -66,6 +74,17 @@ jsPsych.plugins['external-html'] = (function() {
         display_element.innerHTML = '';
         jsPsych.finishTrial(trial_data);
       };
+
+      // by default, scripts on the external page are not executed with XMLHttpRequest().
+      // To activate their content through DOM manipulation, we need to relocate all script tags
+      if (trial.execute_Script) {
+        for (const scriptElement of display_element.getElementsByTagName("script")) {
+        const relocatedScript = document.createElement("script");
+        relocatedScript.text = scriptElement.text;
+        scriptElement.parentNode.replaceChild(relocatedScript, scriptElement);
+        };
+      }
+
       if (trial.cont_btn) { display_element.querySelector('#'+trial.cont_btn).addEventListener('click', finish); }
       if (trial.cont_key) {
         var key_listener = function(e) {


### PR DESCRIPTION
This is an optional paramter in a external-html plugin trial.

Issue #532 addresses the issue that scripts included in the remote page will not be executed via the XMLHttpRequest() in the external-html script.

We will need to relocate the content of all scripts by relocating the content through DOM manipulation. The execution is optional and can be controlled through the new execute_Script parameter.