### PR TITLE
CSS imports must be at beginning of file.

### DIFF
--- a/css/jspsych.css
+++ b/css/jspsych.css
@@ -7,6 +7,8 @@
 
  /* Container holding jsPsych content */
 
+ @import url(https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700);
+
  .jspsych-display-element {
    display: flex;
    flex-direction: column;
@@ -39,8 +41,6 @@
  }
 
 /* fonts and type */
-
-@import url(https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700);
 
 .jspsych-display-element {
   font-family: 'Open Sans', 'Arial', sans-serif;


### PR DESCRIPTION
As it's currently written, the Open Sans font is never being loaded. See, for instance, https://developer.mozilla.org/en-US/docs/Web/CSS/@import