### PR TITLE
Update jspsych-external-html.js

### DIFF
--- a/plugins/jspsych-external-html.js
+++ b/plugins/jspsych-external-html.js
@@ -66,7 +66,7 @@ jsPsych.plugins['external-html'] = (function() {
       var t0 = (new Date()).getTime();
       var finish = function() {
         if (trial.check_fn && !trial.check_fn(display_element)) { return };
-        if (trial.cont_key) { document.removeEventListener('keydown', key_listener); }
+        if (trial.cont_key) { display_element.removeEventListener('keydown', key_listener); }
         var trial_data = {
           rt: (new Date()).getTime() - t0,
           url: trial.url


### PR DESCRIPTION
I found a minor bug on line 69.
Error: if (trial.cont_key) { document.removeEventListener('keydown', key_listener); }
Correct: if (trial.cont_key) { display_element.removeEventListener('keydown', key_listener); }
Because of this, some eventListeners continue working after finishing this plugin.