### PR TITLE
Added flag allowing to avoid saving html-keyboard-response stimulus to data

### DIFF
--- a/jspsych.js
+++ b/jspsych.js
@@ -224,6 +224,13 @@ window.jsPsych = (function() {
     data = typeof data == 'undefined' ? {} : data;
 
     if (current_trial.hasOwnProperty('ignored_data')) {
+      // Single key to ignore
+      if (typeof current_trial.ignored_data === 'string') {
+        if (data.hasOwnProperty(current_trial.ignored_data)) {
+          delete data[current_trial.ignored_data];
+        }
+      }
+      // Multiple keys to ignore
       for (let ignored_key of current_trial.ignored_data) {
         if (data.hasOwnProperty(ignored_key)) {
           delete data[ignored_key];

--- a/jspsych.js
+++ b/jspsych.js
@@ -222,6 +222,15 @@ window.jsPsych = (function() {
 
     // write the data from the trial
     data = typeof data == 'undefined' ? {} : data;
+
+    if (current_trial.hasOwnProperty('ignored_data')) {
+      for (let ignored_key of current_trial.ignored_data) {
+        if (data.hasOwnProperty(ignored_key)) {
+          delete data[ignored_key];
+        }
+      }
+    }
+
     jsPsych.data.write(data);
 
     // get back the data with all of the defaults in

--- a/plugins/jspsych-html-keyboard-response.js
+++ b/plugins/jspsych-html-keyboard-response.js
@@ -54,12 +54,6 @@ jsPsych.plugins["html-keyboard-response"] = (function() {
         default: true,
         description: 'If true, trial will end when subject makes a response.'
       },
-      save_stimulus: {
-        type: jsPsych.plugins.parameterType.BOOL,
-        pretty_name: 'Save stimulus to data',
-        default: true,
-        description: 'If true, stimulus HTML will be saved to the data for this trial.'
-      },
     }
   }
 
@@ -95,12 +89,10 @@ jsPsych.plugins["html-keyboard-response"] = (function() {
       // gather the data to store for the trial
       var trial_data = {
         "rt": response.rt,
+        "stimulus": trial.stimulus,
         "key_press": response.key
-      };
 
-      if (trial.save_stimulus) {
-        trial_data["stimulus"] = trial.stimulus;
-      }
+      };
 
       // clear the display
       display_element.innerHTML = '';

--- a/plugins/jspsych-html-keyboard-response.js
+++ b/plugins/jspsych-html-keyboard-response.js
@@ -54,7 +54,12 @@ jsPsych.plugins["html-keyboard-response"] = (function() {
         default: true,
         description: 'If true, trial will end when subject makes a response.'
       },
-
+      save_stimulus: {
+        type: jsPsych.plugins.parameterType.BOOL,
+        pretty_name: 'Save stimulus to data',
+        default: true,
+        description: 'If true, stimulus HTML will be saved to the data for this trial.'
+      },
     }
   }
 
@@ -90,9 +95,12 @@ jsPsych.plugins["html-keyboard-response"] = (function() {
       // gather the data to store for the trial
       var trial_data = {
         "rt": response.rt,
-        "stimulus": trial.stimulus,
         "key_press": response.key
       };
+
+      if (trial.save_stimulus) {
+        trial_data["stimulus"] = trial.stimulus;
+      }
 
       // clear the display
       display_element.innerHTML = '';

--- a/tests/jsPsych.data/datamodule.test.js
+++ b/tests/jsPsych.data/datamodule.test.js
@@ -165,6 +165,19 @@ describe('#ignoredData', function(){
     expect(jsPsych.data.get().select('stimulus').count()).toBe(0);
   });
 
+  test('Ignoring multiple data should cause all to disappear', function(){
+    var timeline = [
+      {type: 'html-keyboard-response', stimulus:'hello', ignored_data:['stimulus', 'rt']}
+    ];
+    jsPsych.init({timeline:timeline});
+    // click through first trial
+    utils.pressKey(32);
+    // check if data contains testprop
+    expect(jsPsych.data.get().select('rt').count()).toBe(0);
+    expect(jsPsych.data.get().select('stimulus').count()).toBe(0);
+    expect(jsPsych.data.get().select('key_press').count()).toBe(1);
+  });
+
   test('Adding ignored data for field nonexistent field does nothing', function(){
     var timeline = [
       {type: 'html-keyboard-response', stimulus:'hello', ignored_data:'nonexistent'}
@@ -175,6 +188,19 @@ describe('#ignoredData', function(){
     // check if data contains testprop
     expect(jsPsych.data.get().select('rt').count()).toBe(1);
     expect(jsPsych.data.get().select('stimulus').count()).toBe(1);
+  });
+
+  test('Ignoring mixture of existent and nonexistent keys', function(){
+    var timeline = [
+      {type: 'html-keyboard-response', stimulus:'hello', ignored_data:['stimulus', 'test']}
+    ];
+    jsPsych.init({timeline:timeline});
+    // click through first trial
+    utils.pressKey(32);
+    // check if data contains testprop
+    expect(jsPsych.data.get().select('rt').count()).toBe(1);
+    expect(jsPsych.data.get().select('stimulus').count()).toBe(0);
+    expect(jsPsych.data.get().select('key_press').count()).toBe(1);
   });
 
 });

--- a/tests/jsPsych.data/datamodule.test.js
+++ b/tests/jsPsych.data/datamodule.test.js
@@ -15,7 +15,7 @@ describe('Basic data recording', function(){
     // check if data contains rt
     expect(jsPsych.data.get().select('rt').count()).toBe(1);
   })
-})
+});
 
 describe('#addProperties', function(){
 
@@ -149,4 +149,32 @@ describe('#displayData', function(){
     var html = jsPsych.getDisplayElement().innerHTML;
     expect(html).toBe("<pre id=\"jspsych-data-display\">\"col1\",\"col2\"\r\n\"1\",\"2\"\r\n\"3\",\"4\"\r\n</pre>");
   });
+});
+
+describe('#ignoredData', function(){
+
+  test('Adding ignored data should cause the data to disappear', function(){
+    var timeline = [
+      {type: 'html-keyboard-response', stimulus:'hello', ignored_data:'stimulus'}
+    ];
+    jsPsych.init({timeline:timeline});
+    // click through first trial
+    utils.pressKey(32);
+    // check if data contains testprop
+    expect(jsPsych.data.get().select('rt').count()).toBe(1);
+    expect(jsPsych.data.get().select('stimulus').count()).toBe(0);
+  });
+
+  test('Adding ignored data for field nonexistent field does nothing', function(){
+    var timeline = [
+      {type: 'html-keyboard-response', stimulus:'hello', ignored_data:'nonexistent'}
+    ];
+    jsPsych.init({timeline:timeline});
+    // click through first trial
+    utils.pressKey(32);
+    // check if data contains testprop
+    expect(jsPsych.data.get().select('rt').count()).toBe(1);
+    expect(jsPsych.data.get().select('stimulus').count()).toBe(1);
+  });
+
 });


### PR DESCRIPTION
Hello,

We're implementing an experiment in jsPsych using SVG to render the stimuli in the browser. Using SVG stimuli works fantastically well, other than the fact it balloons our data to the point that made working with it quite uncomfortable, as it added a few hundred characters for many of the trials in our experiment. We also did not need the HTML stimulus saved, as we save a compact description of it to the relevant trials. 

As a workaround, and to avoid some DB-related issues this increased data size was giving us, I added a flag to `html-keyboard-response` to allow not saving the stimulus to the data. The default behavior, of course, is to save, as to maintain backward compatibility. 

I didn't know if there are any other plugins for which a similar functionality might make sense, but I'd be happy to add it anywhere else it would be reasonable. 

Let me know what you think.

Thanks!

-Guy Davidson