### PR TITLE
make shuffleNoRepeats check last two elements

### DIFF
--- a/jspsych.js
+++ b/jspsych.js
@@ -1695,7 +1695,7 @@ jsPsych.randomization = (function() {
     }
 
     var random_shuffle = shuffle(arr);
-    for (var i = 0; i < random_shuffle.length - 2; i++) {
+    for (var i = 0; i < random_shuffle.length - 1; i++) {
       if (equalityTest(random_shuffle[i], random_shuffle[i + 1])) {
         // neighbors are equal, pick a new random neighbor to swap (not the first or last element, to avoid edge cases)
         var random_pick = Math.floor(Math.random() * (random_shuffle.length - 2)) + 1;


### PR DESCRIPTION
Currently, `jspsych.randomization.shuffleNoRepeats` doesn't verify that the last two elements are different and sometimes return shuffles in which they match. For (an extreme) example:
```
> jsPsych.randomization.shuffleNoRepeats([1,1])
[1, 1]
```

This should fix that. 

(N.B. This doesn't address the issue that, as noted in the docs, the browser will hang if no shuffles without repeats are possible, as well as in some cases where they are possible but rare. So, with this fix the browser now "correctly" hangs for [1,1].)