### PR TITLE
Option to set video playback rate

### DIFF
--- a/docs/plugins/jspsych-video.md
+++ b/docs/plugins/jspsych-video.md
@@ -16,6 +16,7 @@ autoplay | boolean | true | If true, the video will begin playing as soon as it 
 controls | boolean | false | If true, controls for the video player will be available to the subject. They will be able to pause the video or move the playback to any point in the video.
 start | numeric | null | If given a value, the video will start at this time point in seconds.
 stop| numeric | null | If given a value, the video will stop at this time point in seconds.
+rate | numeric | null | The playback rate of the video. 1 is normal, <1 is slower, >1 is faster.
 
 ## Data Generated
 

--- a/plugins/jspsych-video.js
+++ b/plugins/jspsych-video.js
@@ -65,6 +65,12 @@ jsPsych.plugins.video = (function() {
         pretty_name: 'Stop',
         default: null,
         description: 'Time to stop the clip.'
+      },
+      rate: {
+        type: jsPsych.plugins.parameterType.FLOAT,
+        pretty_name: 'Rate',
+        default: null,
+        description: 'The playback rate of the video. 1 is normal, <1 is slower, >1 is faster.'
       }
     }
   }
@@ -131,6 +137,10 @@ jsPsych.plugins.video = (function() {
 
     if(trial.start !== null){
       display_element.querySelector('#jspsych-video-player').currentTime = trial.start;
+    }
+
+    if(trial.rate !== null){
+      display_element.querySelector('#jspsych-video-player').playbackRate = trial.rate;
     }
 
     // function to end trial when it is time


### PR DESCRIPTION
Add an option to the `jspsych-video` plugin to set the video playback rate. I am just getting started with jsPsych, so let me know if there are any other changes that need to take place before merging. Thank you!