### PR TITLE
Bug in video trial when video is preloaded

### DIFF
--- a/plugins/jspsych-video.js
+++ b/plugins/jspsych-video.js
@@ -99,8 +99,8 @@ jsPsych.plugins.video = (function() {
 
     var video_preload_blob = jsPsych.pluginAPI.getVideoBuffer(trial.sources[0]);
     if(!video_preload_blob) {
-      for(var i=0; i<sources.length; i++){
-        var file_name = sources[i];
+      for(var i=0; i<trial.sources.length; i++){
+        var file_name = trial.sources[i];
         if(file_name.indexOf('?') > -1){
           file_name = file_name.substring(0, file_name.indexOf('?'));
         }


### PR DESCRIPTION
I believe there is a bug in the video plugin. Video trials first try to set the ``src`` to a preloaded video blob. If there is no blob, it should just set the ``src`` field of the ``video`` HTML tag to the list of sources provided as parameters to the trial. However, in the current codebase, if the video is not preloaded, I get the following error on the browser Javascript console:

```
jspsych-video.js:102 Uncaught ReferenceError: sources is not defined
    at Object.jsPsych.plugins.video.plugin.trial (jspsych-video.js:102)
    at doTrial (jspsych.js:833)
    at nextTrial (jspsych.js:801)
    at Object.window.jsPsych.core.finishTrial (jspsych.js:265)
    at end_trial (jspsych-html-keyboard-response.js:101)
    at Object.after_response [as callback_function] (jspsych-html-keyboard-response.js:117)
    at Object.listener_function [as fn] (jspsych.js:1970)
    at HTMLBodyElement.root_keydown_listener (jspsych.js:1889)
jsPsych.plugins.video.plugin.trial @ jspsych-video.js:102
doTrial @ jspsych.js:833
nextTrial @ jspsych.js:801
window.jsPsych.core.finishTrial @ jspsych.js:265
end_trial @ jspsych-html-keyboard-response.js:101
after_response @ jspsych-html-keyboard-response.js:117
listener_function @ jspsych.js:1970
root_keydown_listener @ jspsych.js:1889
```
One straightforward way to reproduce this error is to hardcode the ``var video_preload_blob = undefined;`` https://github.com/jspsych/jsPsych/blob/d6f7002497467d9d03aee74295f0c231190717d8/plugins/jspsych-video.js#L100 (for me this was easier than trying to figure out how to disable video preloading...)

The proposed changes lead to correct behavior -- videos load at the onset of each trial.
