### PR TITLE
external-html example: Replace jQuery with vanilla JS

### DIFF
--- a/docs/plugins/jspsych-external-html.md
+++ b/docs/plugins/jspsych-external-html.md
@@ -49,7 +49,7 @@ rt | numeric | The response time in milliseconds for the subject to finish the t
 // sample function that might be used to check if a subject has given
 // consent to participate.
 var check_consent = function(elem) {
-  if ($('#consent_checkbox').is(':checked')) {
+  if (document.getElementById('consent_checkbox').checked) {
     return true;
   }
   else {


### PR DESCRIPTION
As title! Caught this while helping a student use this for a consent form, the fix was tested in the context of their experiment.