### PR TITLE
Add missing preventDefault() call to survey-text plugin submit

### DIFF
--- a/plugins/jspsych-survey-text.js
+++ b/plugins/jspsych-survey-text.js
@@ -116,6 +116,7 @@ jsPsych.plugins['survey-text'] = (function() {
     display_element.innerHTML = html;
 
     display_element.querySelector('#jspsych-survey-text-form').addEventListener('submit', function() {
+      event.preventDefault();
       // measure response time
       var endTime = performance.now();
       var response_time = endTime - startTime;


### PR DESCRIPTION
It sounds like you
This fixes the issue in https://github.com/jspsych/jsPsych/issues/610

To test:

- Test in Safari or Edge
- Create a survey with the at least two survey-text trials
- Start the experiment
- On the first trial, enter data and attempt to go to the next trial with either pressing enter or clicking the button

- old behavior: The web page refreshes and the experiment starts over
- new behavior: Experiment moves on to the next trial as expected
