### PR TITLE
Update jspsych.js - adding mobile browser detection for exclusions

### DIFF
--- a/jspsych.js
+++ b/jspsych.js
@@ -992,6 +992,17 @@ window.jsPsych = (function() {
         return;
       }
     }
+    // Mobile browser vs. desktop
+    // Checks adapted from http://detectmobilebrowsers.com/
+    if(typeof exclusions.nomobile !== 'undefined' && exclusions.nomobile) {
+      if(/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(navigator.userAgent)||/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(navigator.userAgent.substr(0,4))) {
+        clear = false;
+        var msg = '<p>Mobile browser detected. This experiment cannot be completed on a phone.</p>';
+        core.getDisplayElement().innerHTML = msg;
+        fail();
+        return;
+      }
+    }
 
     // GO?
     if(clear){ success(); }

--- a/plugins/jspsych-categorize-image-buttons.js
+++ b/plugins/jspsych-categorize-image-buttons.js
@@ -1,0 +1,322 @@
+/**
+ *
+ * 
+ * Based on JdL's jspsych-categorize-image.js, and converted to use button presses
+ * 
+ * key_answer: now a string
+ * choices: now an array of strings of button labels (paralleling the other button tools in jsPsych)
+ * button_html: added (parallels all other button_html parameters in jsPsych)
+ * 
+ **/
+
+
+jsPsych.plugins['categorize-image-buttons'] = (function() {
+
+  var plugin = {};
+
+  jsPsych.pluginAPI.registerPreload('categorize-image-buttons', 'stimulus', 'image');
+
+  plugin.info = {
+    name: 'categorize-image-buttons',
+    description: '',
+    parameters: {
+      stimulus: {
+        type: jsPsych.plugins.parameterType.IMAGE,
+        pretty_name: 'Stimulus',
+        default: undefined,
+        description: 'The image content to be displayed.'
+      },
+      button_html: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Button HTML',
+        default: '<button class="jspsych-btn">%choice%</button>',
+        array: true,
+        description: 'The html of the button. Can create own style.'
+      },
+      margin_vertical: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Margin vertical',
+        default: '0px',
+        description: 'The vertical margin of the button.'
+      },
+      margin_horizontal: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Margin horizontal',
+        default: '8px',
+        description: 'The horizontal margin of the button.'
+      },
+      button_answer: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Button answer',
+        default: undefined,
+        description: 'The button index to indicate the correct response.'
+      },
+      choices: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Choices',
+        default: undefined,
+        array: true,
+        description: 'The labels for the buttons.'
+      },
+      text_answer: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Text answer',
+        default: null,
+        description: 'Label that is associated with the correct answer.'
+      },
+      correct_text: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Correct text',
+        default: "<p class='feedback'>Correct</p>",
+        description: 'String to show when correct answer is given.'
+      },
+      incorrect_text: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Incorrect text',
+        default: "<p class='feedback'>Incorrect</p>",
+        description: 'String to show when incorrect answer is given.'
+      },
+      prompt: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Prompt',
+        default: null,
+        description: 'Any content here will be displayed below the stimulus.'
+      },
+      force_correct_button_press: {
+        type: jsPsych.plugins.parameterType.BOOL,
+        pretty_name: 'Force correct button press',
+        default: false,
+        description: 'If set to true, then the subject must press the correct response key after feedback in order to advance to next trial.'
+      },
+      show_stim_with_feedback: {
+        type: jsPsych.plugins.parameterType.BOOL,
+        default: true,
+        no_function: false,
+        description: ''
+      },
+      show_feedback_on_timeout: {
+        type: jsPsych.plugins.parameterType.BOOL,
+        pretty_name: 'Show feedback on timeout',
+        default: false,
+        description: 'If true, stimulus will be shown during feedback. If false, only the text feedback will be displayed during feedback.'
+      },
+      timeout_message: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Timeout message',
+        default: "<p>Please respond faster.</p>",
+        description: 'The message displayed on a timeout non-response.'
+      },
+      stimulus_duration: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Stimulus duration',
+        default: null,
+        description: 'How long to hide stimulus.'
+      },
+      trial_duration: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Trial duration',
+        default: null,
+        description: 'How long to show trial'
+      },
+      feedback_duration: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Feedback duration',
+        default: 2000,
+        description: 'How long to show feedback.'
+      }
+    }
+  }
+
+  plugin.trial = function(display_element, trial) {
+
+    display_element.innerHTML = '<img id="jspsych-categorize-image-buttons-stimulus" class="jspsych-categorize-image-buttons-stimulus" src="'+trial.stimulus+'"></img>';
+
+    // hide image after time if the timing parameter is set
+    if (trial.stimulus_duration !== null) {
+      jsPsych.pluginAPI.setTimeout(function() {
+        display_element.querySelector('#jspsych-categorize-image-buttons-stimulus').style.visibility = 'hidden';
+      }, trial.stimulus_duration);
+    }
+
+    //display buttons
+    var buttons = [];
+    if (Array.isArray(trial.button_html)) {
+      if (trial.button_html.length == trial.choices.length) {
+        buttons = trial.button_html;
+      } else {
+        console.error('Error in categorize-image-buttons plugin. The length of the button_html array does not equal the length of the choices array');
+      }
+    } else {
+      for (var i = 0; i < trial.choices.length; i++) {
+        buttons.push(trial.button_html);
+      }
+    }
+    display_element.innerHTML += '<div id="jspsych-categorize-image-buttons-btngroup">';
+
+    for (var i = 0; i < trial.choices.length; i++) {
+      var str = buttons[i].replace(/%choice%/g, trial.choices[i]);
+      display_element.innerHTML += '<div class="jspsych-categorize-image-buttons-button" style="display: inline-block; margin:'+trial.margin_vertical+' '+trial.margin_horizontal+'" id="jspsych-categorize-image-buttons-button-' + i +'" data-choice="'+i+'">'+str+'</div>';
+    }
+    display_element.innerHTML += '</div>';
+
+    // if prompt is set, show prompt
+    if (trial.prompt !== null) {
+      display_element.innerHTML += trial.prompt;
+    }
+
+    // start timing
+    var start_time = performance.now();
+
+    var trial_data = {};
+
+    // create response function
+    function after_response(choice) {
+
+        // measure rt
+        var end_time = performance.now();
+        var rt = end_time - start_time;
+        response.button = choice;  // 0=Same/Yes, 1=Diff/no
+        response.rt = rt;
+
+        // kill any remaining setTimeout handlers
+        jsPsych.pluginAPI.clearAllTimeouts();
+
+        var correct = false;
+        if (choice == trial.button_answer) {correct = true; }
+
+        // after a valid response, the stimulus will have the CSS class 'responded'
+        // which can be used to provide visual feedback that a response was recorded
+        //display_element.querySelector('#jspsych-yesno-match-stimulus').className += ' responded';
+
+        // disable all the buttons after a response
+        var btns = document.querySelectorAll('.jspsych-categorize-image-buttons-button button');
+        for(var i=0; i<btns.length; i++){
+          console.log('disabled button ' + i);
+          btns[i].setAttribute('disabled', 'disabled');
+        }
+        var trial_data = {
+          "rt": response.rt,
+          "correct": correct,
+          "stimulus": trial.stimulus,
+          "button_pressed": response.button
+        };
+
+    //   // save data
+    //   trial_data = {
+    //     "rt": info.rt,
+    //     "correct": correct,
+    //     "stimulus": trial.stimulus,
+    //     "key_press": info.key
+    //   };
+
+        display_element.innerHTML = '';
+
+        var timeout = choice == null;
+        doFeedback(correct, timeout);
+    }
+
+    // jsPsych.pluginAPI.getKeyboardResponse({
+    //   callback_function: after_response,
+    //   valid_responses: trial.choices,
+    //   rt_method: 'performance',
+    //   persist: false,
+    //   allow_held_key: false
+    // });
+
+
+    for (var i = 0; i < trial.choices.length; i++) {
+        display_element.querySelector('#jspsych-categorize-image-buttons-button-' + i).addEventListener('click',function(e){
+            var choice = e.currentTarget.getAttribute('data-choice'); // don't use dataset for jsdom compatibility
+            after_response(choice);
+          });
+    }
+    // store response
+    var response = {
+    rt: null,
+    button: null
+    };
+
+    if (trial.trial_duration !== null) {
+      jsPsych.pluginAPI.setTimeout(function() {
+        after_response(null);
+      }, trial.trial_duration);
+    }
+
+    function doFeedback(correct, timeout) {
+
+      if (timeout && !trial.show_feedback_on_timeout) {
+        display_element.innerHTML += trial.timeout_message;
+      } else {
+        // show image during feedback if flag is set
+        if (trial.show_stim_with_feedback) {
+          display_element.innerHTML = '<img id="jspsych-categorize-image-buttons-stimulus" class="jspsych-categorize-image-buttons-stimulus" src="'+trial.stimulus+'"></img>';
+        }
+
+        // substitute answer in feedback string.
+        var atext = "";
+        if (correct) {
+          atext = trial.correct_text.replace("%ANS%", trial.text_answer);
+        } else {
+          atext = trial.incorrect_text.replace("%ANS%", trial.text_answer);
+        }
+
+        // show the feedback
+        display_element.innerHTML += atext;
+      }
+      // check if force correct button press is set
+      if (trial.force_correct_button_press && correct === false && ((timeout && trial.show_feedback_on_timeout) || !timeout)) {
+
+        // Recreate all our buttons
+        var buttons = [];
+        if (Array.isArray(trial.button_html)) {
+          if (trial.button_html.length == trial.choices.length) {
+            buttons = trial.button_html;
+          } else {
+            console.error('Error in categorize-image-buttons plugin. The length of the button_html array does not equal the length of the choices array');
+          }
+        } else {
+          for (var i = 0; i < trial.choices.length; i++) {
+            buttons.push(trial.button_html);
+          }
+        }
+        display_element.innerHTML += '<div id="jspsych-categorize-image-buttons-btngroup">';
+    
+        for (var i = 0; i < trial.choices.length; i++) {
+          var str = buttons[i].replace(/%choice%/g, trial.choices[i]);
+          display_element.innerHTML += '<div class="jspsych-categorize-image-buttons-button" style="display: inline-block; margin:'+trial.margin_vertical+' '+trial.margin_horizontal+'" id="jspsych-categorize-image-buttons-button-' + i +'" data-choice="'+i+'">'+str+'</div>';
+        }
+        display_element.innerHTML += '</div>';
+    
+        // Put a listener only on the correct button and have that run endTrial
+        display_element.querySelector('#jspsych-categorize-image-buttons-button-' + trial.button_answer).addEventListener('click',function(e){
+            endTrial();
+        });
+    
+        // jsPsych.pluginAPI.getKeyboardResponse({
+        //   callback_function: after_forced_response,
+        //   valid_responses: [trial.key_answer],
+        //   rt_method: 'performance',
+        //   persist: false,
+        //   allow_held_key: false
+        // });
+
+      } else {
+        jsPsych.pluginAPI.setTimeout(function() {
+          endTrial();
+        }, trial.feedback_duration);
+      }
+
+    }
+
+    function endTrial() {
+      // kill any remaining setTimeout handlers
+      jsPsych.pluginAPI.clearAllTimeouts();
+
+      display_element.innerHTML = '';
+      jsPsych.finishTrial(trial_data);
+    }
+
+  };
+
+  return plugin;
+})();

--- a/plugins/jspsych-delay-yesno-match-buttons.js
+++ b/plugins/jspsych-delay-yesno-match-buttons.js
@@ -1,0 +1,233 @@
+/**
+ * Derived from jspsych-same-different by Josh de Leeuw
+ *
+ * plugin for showing two stimuli sequentially with a mask between them. Will either show the
+ * same image the second time or show the other image the second time. Similar to a delayed
+ * match to sample but doing it as a yes/no (same/different) and not forced choice
+ *
+ * 
+ *
+ */
+
+jsPsych.plugins['delay-yesno-match-buttons'] = (function() {
+
+  var plugin = {};
+
+  jsPsych.pluginAPI.registerPreload('delay-yesno-match-buttons', 'stimuli', 'image')
+
+  plugin.info = {
+    name: 'delay-yesno-match-buttons',
+    description: '',
+    parameters: {
+      stimuli: {
+        type: jsPsych.plugins.parameterType.IMAGE,
+        pretty_name: 'Stimuli',
+        default: undefined,
+        array: true,
+        description: 'The images to be displayed. First is the target and 2nd the potential foil'
+      },
+      button_html: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Button HTML',
+        default: '<button class="jspsych-btn">%choice%</button>',
+        array: true,
+        description: 'The html of the button. Can create own style.'
+      },
+      margin_vertical: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Margin vertical',
+        default: '0px',
+        description: 'The vertical margin of the button.'
+      },
+      margin_horizontal: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Margin horizontal',
+        default: '8px',
+        description: 'The horizontal margin of the button.'
+      },
+      answer: {
+        type: jsPsych.plugins.parameterType.SELECT,
+        pretty_name: 'Answer',
+        options: ['same', 'different'],
+        default: 75,
+        description: 'Either "same" or "different". Controls the correct answer and which is shown second'
+      },
+      same_label: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Same label',
+        default: 'Same',
+        array: false,
+        description: 'The labels for the buttons.'
+      },
+      different_label: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Different label',
+        default: 'Different',
+        array: false,
+        description: 'The labels for the buttons.'
+      },
+      first_stim_duration: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'First stimulus duration',
+        default: 1000,
+        description: 'How long to show the first stimulus for in milliseconds.'
+      },
+      gap_duration: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Gap duration',
+        default: 500,
+        description: 'How long to show the mask in between the two stimuli.'
+      },
+      second_stim_duration: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Second stimulus duration',
+        default: 1000,
+        description: 'How long to show the second stimulus for in milliseconds.'
+      },
+      prompt: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Prompt',
+        default: null,
+        description: 'Any content here will be displayed below the stimulus.'
+      }
+    }
+  }
+
+  plugin.trial = function(display_element, trial) {
+
+    display_element.innerHTML = '<img class="jspsych-yesno-match-stimulus" src="'+trial.stimuli[0]+'"></img>';
+
+    var first_stim_info;
+    if (trial.first_stim_duration > 0) {
+      jsPsych.pluginAPI.setTimeout(function() {
+        showMaskScreen();
+      }, trial.first_stim_duration);
+    } else {
+      function afterKeyboardResponse(info) {
+        first_stim_info = info;
+        showMaskScreen();
+      }
+      jsPsych.pluginAPI.getKeyboardResponse({
+        callback_function: afterKeyboardResponse,
+        valid_responses: trial.advance_key,
+        rt_method: 'performance',
+        persist: false,
+        allow_held_key: false
+      });
+    }
+
+    function showMaskScreen() {
+      display_element.innerHTML = '<img class="jspsych-yesno-match-stimulus" src="'+trial.stimuli[2]+'"></img>';
+
+      jsPsych.pluginAPI.setTimeout(function() {
+        showSecondStim();
+      }, trial.gap_duration);
+    }
+
+    function showSecondStim() {
+
+      var html = '<img class="jspsych-yesno-match-stimulus" src="'+trial.stimuli[1]+'"></img>';
+      if (trial.answer == 'same') {
+        html = '<img class="jspsych-yesno-match-stimulus" src="'+trial.stimuli[0]+'"></img>';
+      }
+
+      // show buttons
+      var buttons = [];
+      buttons.push(trial.button_html);
+      buttons.push(trial.button_html);
+      html += '<div id="jspsych-html-button-response-btngroup">';
+      var str = buttons[0].replace(/%choice%/g, trial.same_label);
+      html += '<div class="jspsych-yesno-match-button-response-button" style="display: inline-block; margin:'+trial.margin_vertical+' '+trial.margin_horizontal+'" id="jspsych-yesno-match-button-response-button-' + 0 +'" data-choice="'+0+'">'+str+'</div>';
+      str = buttons[1].replace(/%choice%/g, trial.different_label);
+      html += '<div class="jspsych-yesno-match-button-response-button" style="display: inline-block; margin:'+trial.margin_vertical+' '+trial.margin_horizontal+'" id="jspsych-yesno-match-button-response-button-' + 1 +'" data-choice="'+1+'">'+str+'</div>';
+      html += '</div>';
+  
+      //show prompt
+      if (trial.prompt !== null) {
+        html += trial.prompt;
+      }
+
+      display_element.innerHTML = html;
+
+      // start timing
+      var start_time = performance.now();
+
+      if (trial.second_stim_duration > 0) {
+        jsPsych.pluginAPI.setTimeout(function() {
+          display_element.querySelector('.jspsych-yesno-match-stimulus').style.visibility = 'hidden';
+        }, trial.second_stim_duration);
+      }
+
+
+      function after_response(choice) {
+
+        // measure rt
+        var end_time = performance.now();
+        var rt = end_time - start_time;
+        response.button = choice;  // 0=Same/Yes, 1=Diff/no
+        response.rt = rt;
+
+        // kill any remaining setTimeout handlers
+        jsPsych.pluginAPI.clearAllTimeouts();
+
+        var correct = false;
+        if (choice == 0 && trial.answer == 'same') {
+          correct = true;
+        }
+        if (choice == 1 && trial.answer == 'different') {
+          correct = true;
+        }
+
+        // after a valid response, the stimulus will have the CSS class 'responded'
+        // which can be used to provide visual feedback that a response was recorded
+        //display_element.querySelector('#jspsych-yesno-match-stimulus').className += ' responded';
+
+        // disable all the buttons after a response
+        var btns = document.querySelectorAll('.jspsych-yesno-match-button-response-button button');
+        for(var i=0; i<btns.length; i++){
+          //btns[i].removeEventListener('click');
+          btns[i].setAttribute('disabled', 'disabled');
+        }
+        var trial_data = {
+          "rt": response.rt,
+          "answer": trial.answer,
+          "correct": correct,
+          "stimulus": JSON.stringify([trial.stimuli[0], trial.stimuli[1]]),
+          "button_pressed": response.button
+        };
+        // if (first_stim_info) {
+        //   trial_data["rt_stim1"] = first_stim_info.rt;
+        //   trial_data["key_press_stim1"] = first_stim_info.key;
+        // }
+
+        display_element.innerHTML = '';
+
+        jsPsych.finishTrial(trial_data);
+      }
+
+      for (var i = 0; i < 2; i++) {
+        display_element.querySelector('#jspsych-yesno-match-button-response-button-' + i).addEventListener('click', function(e){
+          var choice = e.currentTarget.getAttribute('data-choice'); // don't use dataset for jsdom compatibility
+          after_response(choice);
+        });
+      }
+      // store response
+      var response = {
+        rt: null,
+        button: null
+      };
+
+      // jsPsych.pluginAPI.getKeyboardResponse({
+      //   callback_function: after_response,
+      //   valid_responses: [trial.same_key, trial.different_key],
+      //   rt_method: 'performance',
+      //   persist: false,
+      //   allow_held_key: false
+      // });
+
+    }
+
+  };
+
+  return plugin;
+})();

--- a/plugins/jspsych-delay-yesno-match.js
+++ b/plugins/jspsych-delay-yesno-match.js
@@ -1,0 +1,173 @@
+/**
+ * Derived from jspsych-same-different by Josh de Leeuw
+ *
+ * plugin for showing two stimuli sequentially with a mask between them. Will either show the
+ * same image the second time or show the other image the second time. Similar to a delayed
+ * match to sample but doing it as a yes/no (same/different) and not forced choice
+ *
+ * 
+ *
+ */
+
+jsPsych.plugins['delay-yesno-match'] = (function() {
+
+  var plugin = {};
+
+  jsPsych.pluginAPI.registerPreload('delay-yesno-match', 'stimuli', 'image')
+
+  plugin.info = {
+    name: 'delay-yesno-match',
+    description: '',
+    parameters: {
+      stimuli: {
+        type: jsPsych.plugins.parameterType.IMAGE,
+        pretty_name: 'Stimuli',
+        default: undefined,
+        array: true,
+        description: 'The images to be displayed. First is the target and 2nd the potential foil'
+      },
+      answer: {
+        type: jsPsych.plugins.parameterType.SELECT,
+        pretty_name: 'Answer',
+        options: ['same', 'different'],
+        default: 75,
+        description: 'Either "same" or "different". Controls the correct answer and which is shown second'
+      },
+      same_key: {
+        type: jsPsych.plugins.parameterType.KEYCODE,
+        pretty_name: 'Same key',
+        default: 'Q',
+        description: ''
+      },
+      different_key: {
+        type: jsPsych.plugins.parameterType.KEYCODE,
+        pretty_name: 'Different key',
+        default: 'P',
+        description: 'The key that subjects should press to indicate that the two stimuli are the same.'
+      },
+      first_stim_duration: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'First stimulus duration',
+        default: 1000,
+        description: 'How long to show the first stimulus for in milliseconds.'
+      },
+      gap_duration: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Gap duration',
+        default: 500,
+        description: 'How long to show the mask in between the two stimuli.'
+      },
+      second_stim_duration: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Second stimulus duration',
+        default: 1000,
+        description: 'How long to show the second stimulus for in milliseconds.'
+      },
+      prompt: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Prompt',
+        default: null,
+        description: 'Any content here will be displayed below the stimulus.'
+      }
+    }
+  }
+
+  plugin.trial = function(display_element, trial) {
+
+    display_element.innerHTML = '<img class="jspsych-yesno-match-stimulus" src="'+trial.stimuli[0]+'"></img>';
+
+    var first_stim_info;
+    if (trial.first_stim_duration > 0) {
+      jsPsych.pluginAPI.setTimeout(function() {
+        showMaskScreen();
+      }, trial.first_stim_duration);
+    } else {
+      function afterKeyboardResponse(info) {
+        first_stim_info = info;
+        showMaskScreen();
+      }
+      jsPsych.pluginAPI.getKeyboardResponse({
+        callback_function: afterKeyboardResponse,
+        valid_responses: trial.advance_key,
+        rt_method: 'performance',
+        persist: false,
+        allow_held_key: false
+      });
+    }
+
+    function showMaskScreen() {
+      display_element.innerHTML = '<img class="jspsych-yesno-match-stimulus" src="'+trial.stimuli[2]+'"></img>';
+
+      jsPsych.pluginAPI.setTimeout(function() {
+        showSecondStim();
+      }, trial.gap_duration);
+    }
+
+    function showSecondStim() {
+
+      var html = '<img class="jspsych-yesno-match-stimulus" src="'+trial.stimuli[1]+'"></img>';
+      if (trial.answer == 'same') {
+        html = '<img class="jspsych-yesno-match-stimulus" src="'+trial.stimuli[0]+'"></img>';
+      }
+      //show prompt
+      if (trial.prompt !== null) {
+        html += trial.prompt;
+      }
+
+      display_element.innerHTML = html;
+
+      if (trial.second_stim_duration > 0) {
+        jsPsych.pluginAPI.setTimeout(function() {
+          display_element.querySelector('.jspsych-yesno-match-stimulus').style.visibility = 'hidden';
+        }, trial.second_stim_duration);
+      }
+
+      var after_response = function(info) {
+
+        // kill any remaining setTimeout handlers
+        jsPsych.pluginAPI.clearAllTimeouts();
+
+        var correct = false;
+
+        var skey = typeof trial.same_key == 'string' ? jsPsych.pluginAPI.convertKeyCharacterToKeyCode(trial.same_key) : trial.same_key;
+        var dkey = typeof trial.different_key == 'string' ? jsPsych.pluginAPI.convertKeyCharacterToKeyCode(trial.different_key) : trial.different_key;
+
+        if (info.key == skey && trial.answer == 'same') {
+          correct = true;
+        }
+
+        if (info.key == dkey && trial.answer == 'different') {
+          correct = true;
+        }
+
+        var trial_data = {
+          "rt": info.rt,
+          "answer": trial.answer,
+          "correct": correct,
+          "stimulus": JSON.stringify([trial.stimuli[0], trial.stimuli[1]]),
+          "key_press": info.key
+        };
+        if (first_stim_info) {
+          trial_data["rt_stim1"] = first_stim_info.rt;
+          trial_data["key_press_stim1"] = first_stim_info.key;
+        }
+
+        display_element.innerHTML = '';
+
+        jsPsych.finishTrial(trial_data);
+      }
+
+      jsPsych.pluginAPI.getKeyboardResponse({
+        callback_function: after_response,
+        valid_responses: [trial.same_key, trial.different_key],
+        rt_method: 'performance',
+        persist: false,
+        allow_held_key: false
+      });
+
+    }
+
+  };
+
+  return plugin;
+})();

--- a/plugins/jspsych-image-button-response.js
+++ b/plugins/jspsych-image-button-response.js
@@ -117,7 +117,7 @@ jsPsych.plugins["image-button-response"] = (function() {
     if (trial.stimulus_width !== null) {
       size_spec += ' width='+trial.stimulus_width;
     }
-    var new_html = '<img src="'+trial.stimulus+'" id="jspsych-image-keyboard-response-stimulus"' + size_spec + ' ></img>';
+    var html = '<img src="'+trial.stimulus+'" id="jspsych-image-button-response-stimulus"' + size_spec + ' ></img>';
     if(trial.stimulus_height !== null){
       html += 'height:'+trial.stimulus_height+'px; '
       if(trial.stimulus_width == null && trial.maintain_aspect_ratio){

--- a/plugins/jspsych-image-button-response.js
+++ b/plugins/jspsych-image-button-response.js
@@ -92,13 +92,32 @@ jsPsych.plugins["image-button-response"] = (function() {
         default: true,
         description: 'If true, then trial will end when user responds.'
       },
+      stimulus_width: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Stimulus width',
+        default: null,
+        description: 'How wide is the image'
+      },
+      stimulus_height: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Stimulus height',
+        default: null,
+        description: 'How wide is the image'
+      },
     }
   }
 
   plugin.trial = function(display_element, trial) {
 
     // display stimulus
-    var html = '<img src="'+trial.stimulus+'" id="jspsych-image-button-response-stimulus" style="';
+    var size_spec = '';
+    if (trial.stimulus_height !== null) {
+      size_spec += ' height='+trial.stimulus_height;
+    }
+    if (trial.stimulus_width !== null) {
+      size_spec += ' width='+trial.stimulus_width;
+    }
+    var new_html = '<img src="'+trial.stimulus+'" id="jspsych-image-keyboard-response-stimulus"' + size_spec + ' ></img>';
     if(trial.stimulus_height !== null){
       html += 'height:'+trial.stimulus_height+'px; '
       if(trial.stimulus_width == null && trial.maintain_aspect_ratio){

--- a/plugins/jspsych-image-keyboard-response.js
+++ b/plugins/jspsych-image-keyboard-response.js
@@ -74,13 +74,32 @@ jsPsych.plugins["image-keyboard-response"] = (function() {
         default: true,
         description: 'If true, trial will end when subject makes a response.'
       },
+      stimulus_width: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Stimulus width',
+        default: null,
+        description: 'How wide is the image'
+      },
+      stimulus_height: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Stimulus height',
+        default: null,
+        description: 'How wide is the image'
+      },
     }
   }
 
   plugin.trial = function(display_element, trial) {
 
     // display stimulus
-    var html = '<img src="'+trial.stimulus+'" id="jspsych-image-keyboard-response-stimulus" style="';
+    var size_spec = '';
+    if (trial.stimulus_height !== null) {
+      size_spec += ' height='+trial.stimulus_height;
+    }
+    if (trial.stimulus_width !== null) {
+      size_spec += ' width='+trial.stimulus_width;
+    }
+    var new_html = '<img src="'+trial.stimulus+'" id="jspsych-image-keyboard-response-stimulus"' + size_spec + ' ></img>';
     if(trial.stimulus_height !== null){
       html += 'height:'+trial.stimulus_height+'px; '
       if(trial.stimulus_width == null && trial.maintain_aspect_ratio){


### PR DESCRIPTION
Using the regexp from the open-source http://detectmobilebrowsers.com, I've added an exclusions.nomobile option.  Set to true exclude phones.  This can be elaborated on to also exclude tablets.