### PR TITLE
Fix Chrome AudioContext issue

### DIFF
--- a/plugins/jspsych-audio-button-response.js
+++ b/plugins/jspsych-audio-button-response.js
@@ -197,6 +197,7 @@ jsPsych.plugins["audio-button-response"] = (function() {
 
 		// start audio
     if(context !== null){
+      context.resume();
       startTime = context.currentTime;
       source.start(startTime);
     } else {


### PR DESCRIPTION
New versions of Chrome prevent automatic audio playback. This implements the same fix as in issue #518