### PR TITLE
Allow passing a plugin object as trial_parameter.type

### DIFF
--- a/tests/jsPsych/endexperiment.test.js
+++ b/tests/jsPsych/endexperiment.test.js
@@ -47,3 +47,46 @@ test('works with looping timeline (#541)', function(){
 
     expect(jsPsych.getDisplayElement().innerHTML).toMatch('the end');
 });
+
+test('works with object as trial type', function(){
+    var timeline = [
+        {
+            type: {
+                info: {
+                    name: 'test-plugin',
+                    parameters: {
+                        stimulus: {
+                            type: jsPsych.plugins.parameterType.STRING,
+                            default: undefined
+                        }
+                    }
+                },
+                trial: function(display_element, trial) {
+                    display_element.innerHTML = trial.stimulus
+
+                    var keyboardListener = jsPsych.pluginAPI.getKeyboardResponse({
+                        callback_function: function () {
+                            var data = {};
+                            jsPsych.finishTrial(data);
+
+                            jsPsych.pluginAPI.cancelKeyboardResponse(keyboardListener);
+                        },
+                        rt_method: 'performance',
+                        persist: false,
+                        allow_held_key: false
+                    })
+                  }
+            },
+            stimulus: 'test trial',
+            on_finish: function(){ jsPsych.endExperiment('the end') }
+        }
+    ]
+
+    jsPsych.init({timeline});
+
+    expect(jsPsych.getDisplayElement().innerHTML).toMatch('test trial');
+
+    utils.pressKey(32);
+
+    expect(jsPsych.getDisplayElement().innerHTML).toMatch('the end');
+});


### PR DESCRIPTION
Hi @jodeleeuw ,

this pull request extends jsPsych in such a way, that you can now pass an object instead of only a string as `trial_parameter.type`.

This lays the groundwork for doing things such as this from #529 in the future:
```
import htmlKeyboardResponse from "./plugins/jspsych-html-keyboard-response.js"

var trial = {
  type: htmlKeyboardResponse,
  stimulus: 'hello world',
  trial_duration: 1000
}

var timeline = [trial];
```