### PR TITLE
Input to submitToTurk must be non-empty

### DIFF
--- a/docs/core_library/jspsych-turk.md
+++ b/docs/core_library/jspsych-turk.md
@@ -13,7 +13,7 @@ jsPsych.turk.submitToTurk(data)
 
 Parameter | Type | Description
 ----------|------|------------
-data | object | The `data` parameter is an object of `key: value` pairs. Any pairs in the `data` parameter will be saved by Mechanical Turk, and can be downloaded in a CSV file through the Mechanical Turk interface.
+data | object | The `data` parameter is an object of `key: value` pairs. Any pairs in the `data` parameter will be saved by Mechanical Turk, and can be downloaded in a CSV file through the Mechanical Turk interface. **Important**: the `data` parameter must contain at least one `key: value` pair, even just a dummy value, or the HIT will not be submitted correctly.
 
 ### Return value
 


### PR DESCRIPTION
If no data are submitted in submitToTurk the user will see an error ("HIT was not submitted correctly") and the task will not complete. This was non-obvious and hard to debug, and I suspect may be a particular problem in jsPsych where people are often saving their data elsewhere, as we were.

Added a note to the parameter documentation for submitToTurk to this effect.

(I appreciate that the downside is that this documents an implementation detail of MTurk which may change).