### PR TITLE
return checkboxes to within label elements

### DIFF
--- a/plugins/jspsych-survey-multi-choice.js
+++ b/plugins/jspsych-survey-multi-choice.js
@@ -140,8 +140,9 @@ jsPsych.plugins['survey-multi-choice'] = (function() {
 
         // add radio button container
         html += '<div id="'+option_id_name+'" class="jspsych-survey-multi-choice-option">';
-        html += '<label class="jspsych-survey-multi-choice-text" for="'+input_id+'">'+question.options[j]+'</label>';
+        html += '<label class="jspsych-survey-multi-choice-text" for="'+input_id+'">';
         html += '<input type="radio" name="'+input_name+'" id="'+input_id+'" value="'+question.options[j]+'" '+required_attr+'></input>';
+        html += question.options[j]+'</label>';
         html += '</div>';
       }
 

--- a/plugins/jspsych-survey-multi-select.js
+++ b/plugins/jspsych-survey-multi-select.js
@@ -146,14 +146,14 @@ jsPsych.plugins['survey-multi-select'] = (function() {
         label.innerHTML = question.options[j];
         label.setAttribute('for', input_id)
 
-        // create  checkboxes
+        // create checkboxes
         var input = document.createElement('input');
         input.setAttribute('type', "checkbox");
         input.setAttribute('name', input_name);
         input.setAttribute('id', input_id);
         input.setAttribute('value', question.options[j])
         form.appendChild(label)
-        form.insertBefore(input, label)
+        label.insertBefore(input, label.firstChild)
       }
     }
     // add submit button


### PR DESCRIPTION
Checkbox elements were previously child elements of their labels.
55106fe increased backwards compatibility, but seems to have
inadvertently made them siblings instead, breaking some css.
This fixes that.