### PR TITLE
RDK dot position bug

### DIFF
--- a/examples/jspsych-RDK.html
+++ b/examples/jspsych-RDK.html
@@ -39,8 +39,26 @@
 			timeline: RDK_trials, //The timeline of all the trials
 			background_color: "white",
 			dot_color: "black"
-			
-		}
+		};
+
+		var test_block_multiple_aperture = {
+			type: "rdk",
+			number_of_apertures: 3,
+			post_trial_gap: 500, //The Inter Trial Interval. You can either have no ITI, or have an ITI but change the display element to be the same color as the stimuli background to prevent flashing between trials
+			number_of_dots: [50, 100, 200], //Total number of dots in each aperture
+			RDK_type: 3, //The type of RDK used
+			choices: ['a', 'l'], //Choices available to be keyed in by participant
+			trial_duration: 1000, //Duration of each trial in ms
+			timeline: RDK_trials, //The timeline of all the trials
+			background_color: "white",
+			dot_color: "black",
+			fixation_cross: true,
+			aperture_center_x: function () { //aperture will always stay at the same location relative to the center of the screen by using dynamic parameters
+				return [window.innerWidth/2-300, window.innerWidth/2, window.innerWidth/2+300];
+			},
+			aperture_width: 200,
+			aperture_height: 100
+		};
 
 
 		
@@ -48,7 +66,7 @@
 		
 		//Initiate the experiment
 		jsPsych.init({
-			timeline: [test_block],
+			timeline: [test_block, test_block_multiple_aperture],
 			on_finish: function(){ //Execute this when the experiment finishes
 				jsPsych.data.displayData(); //Display the data onto the browser screen
 			}

--- a/plugins/jspsych-rdk.js
+++ b/plugins/jspsych-rdk.js
@@ -161,13 +161,17 @@ jsPsych.plugins["rdk"] = (function() {
 		    aperture_center_x: {
 		      type: jsPsych.plugins.parameterType.INT,
 		      pretty_name: "Aperture center X",
-		      default: window.innerWidth/2,
+		      default: function(){
+		      	return window.innerWidth/2;
+			  },
 		      description: "The x-coordinate of the center of the aperture"
 		    },
 		    aperture_center_y: {
 		      type: jsPsych.plugins.parameterType.INT,
 		      pretty_name: "Aperture center Y",
-		      default: window.innerHeight/2,
+		      default: function(){
+		      	return window.innerHeight/2;
+			  },
 		      description: "The y-coordinate of the center of the aperture"
 		    },
 		    fixation_cross: {
@@ -1351,6 +1355,7 @@ jsPsych.plugins["rdk"] = (function() {
 		
 		//Function to assign the default values for the staircase parameters
 		function assignParameterValue(argument, defaultValue){
+			if(typeof argument === 'function') argument = argument.call();
 			return typeof argument !== 'undefined' ? argument : defaultValue;
 		}
 		


### PR DESCRIPTION
Current RDK plugin has will always present the dot cloud(s) at the same position throughout the course of an experiment. However, the fixation cross is always rendered at the center of the canvas. It would be desirable to keep the dot could(s) also at the center of the canvas. This pull request is suppose to provide the option keeping both the dot clouds at the center of the canvas. 

![afterchange](https://user-images.githubusercontent.com/17289190/77018265-48096a00-6953-11ea-8a61-08f5f3f291a9.png)
![beforechange](https://user-images.githubusercontent.com/17289190/77018266-48a20080-6953-11ea-9156-0529ce98da4a.png)
