### PR TITLE
Enable to respond by clicking string directly.

### DIFF
--- a/plugins/jspsych-survey-likert.js
+++ b/plugins/jspsych-survey-likert.js
@@ -120,11 +120,11 @@ jsPsych.plugins['survey-likert'] = (function() {
       var width = 100 / question.labels.length;
       var options_string = '<ul class="jspsych-survey-likert-opts" data-name="'+question.name+'" data-radio-group="Q' + question_order[i] + '">';
       for (var j = 0; j < question.labels.length; j++) {
-        options_string += '<li style="width:' + width + '%"><input type="radio" name="Q' + question_order[i] + '" value="' + j + '"';
+        options_string += '<li style="width:' + width + '%"><label class="jspsych-survey-likert-opt-label"><input type="radio" name="Q' + question_order[i] + '" value="' + j + '"';
         if(question.required){
           options_string += ' required';
         }
-        options_string += '><label class="jspsych-survey-likert-opt-label">' + question.labels[j] + '</label></li>';
+        options_string += '>' + question.labels[j] + '</label></li>';
       }
       options_string += '</ul>';
       html += options_string;


### PR DESCRIPTION
The jspsych-survey-likert.js plugin admits a participant to click the radio button. But this compels the participant to click it very carefully.

I changed the plugin to enable to respond using not only the radio button but also the associated string.

Best regards,
Daiichiro Kuroki