### PR TITLE
Removed closing </link> tag

### DIFF
--- a/docs/tutorials/hello-world.md
+++ b/docs/tutorials/hello-world.md
@@ -66,7 +66,7 @@ You may also want to import the jsPsych stylesheet, which applies a basic set of
 	<head>
 		<title>My experiment</title>
 		<script src="jspsych-6.0.5/jspsych.js"></script>
-		<link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+		<link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
 	</head>
 	<body></body>
 </html>
@@ -83,7 +83,7 @@ For the demo, we want to show some text on the screen. This is exactly what the 
 		<title>My experiment</title>
 		<script src="jspsych-6.0.5/jspsych.js"></script>
 		<script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
-		<link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+		<link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
 	</head>
 	<body></body>
 </html>
@@ -100,7 +100,7 @@ To add JavaScript code directly to the webpage we need to add a set of `<script>
 		<title>My experiment</title>
 		<script src="jspsych-6.0.5/jspsych.js"></script>
 		<script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
-		<link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+		<link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
 	</head>
 	<body></body>
 	<script>
@@ -123,7 +123,7 @@ Now that we have the trial defined we just need to tell jsPsych to run an experi
 		<title>My experiment</title>
 		<script src="jspsych-6.0.5/jspsych.js"></script>
 		<script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
-		<link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+		<link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
 	</head>
 	<body></body>
 	<script>

--- a/docs/tutorials/rt-task.md
+++ b/docs/tutorials/rt-task.md
@@ -20,7 +20,7 @@ Start by downloading jsPsych and setting up a folder to contain your experiment 
     <title>My experiment</title>
     <script src="jspsych-6.0.5/jspsych.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
-    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
   </head>
   <body></body>
 </html>
@@ -70,7 +70,7 @@ jsPsych.init({
     <title>My experiment</title>
     <script src="jspsych-6.0.5/jspsych.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
-    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
   </head>
   <body></body>
   <script>
@@ -137,7 +137,7 @@ timeline.push(instructions);
     <title>My experiment</title>
     <script src="jspsych-6.0.5/jspsych.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
-    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
   </head>
   <body></body>
   <script>
@@ -189,7 +189,7 @@ Creating trials to show the stimuli is conceptually the same as creating a trial
   <script src="jspsych-6.0.5/jspsych.js"></script>
   <script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
   <script src="jspsych-6.0.5/plugins/jspsych-image-keyboard-response.js"></script>
-  <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+  <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
 </head>
 ```
 
@@ -225,7 +225,7 @@ timeline.push(blue_trial, orange_trial);
     <script src="jspsych-6.0.5/jspsych.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-image-keyboard-response.js"></script>
-    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
   </head>
   <body></body>
   <script>
@@ -346,7 +346,7 @@ What happens when the experiment reaches the test procedure? jsPsych will run th
     <script src="jspsych-6.0.5/jspsych.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-image-keyboard-response.js"></script>
-    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
   </head>
   <body></body>
   <script>
@@ -447,7 +447,7 @@ var test_procedure = {
     <script src="jspsych-6.0.5/jspsych.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-image-keyboard-response.js"></script>
-    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
   </head>
   <body></body>
   <script>
@@ -546,7 +546,7 @@ In the code above, we replaced the `trial_duration: 1000` parameter in `fixation
     <script src="jspsych-6.0.5/jspsych.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-image-keyboard-response.js"></script>
-    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
   </head>
   <body></body>
   <script>
@@ -643,7 +643,7 @@ jsPsych.init({
     <script src="jspsych-6.0.5/jspsych.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-image-keyboard-response.js"></script>
-    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
   </head>
   <body></body>
   <script>
@@ -769,7 +769,7 @@ var fixation = {
     <script src="jspsych-6.0.5/jspsych.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-image-keyboard-response.js"></script>
-    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
   </head>
   <body></body>
   <script>
@@ -880,7 +880,7 @@ The `data.key_press` value is a numeric key code indicating which key the subjec
     <script src="jspsych-6.0.5/jspsych.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-image-keyboard-response.js"></script>
-    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
   </head>
   <body></body>
   <script>
@@ -1007,7 +1007,7 @@ This code is available in the examples folder in the jsPsych download. It is cal
     <script src="jspsych-6.0.5/jspsych.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-html-keyboard-response.js"></script>
     <script src="jspsych-6.0.5/plugins/jspsych-image-keyboard-response.js"></script>
-    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+    <link href="jspsych-6.0.5/css/jspsych.css" rel="stylesheet" type="text/css">
   </head>
   <body></body>
   <script>

--- a/examples/add-to-end-of-timeline.html
+++ b/examples/add-to-end-of-timeline.html
@@ -4,7 +4,7 @@
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-html-keyboard-response.js"></script>
     <script src="../plugins/jspsych-image-keyboard-response.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/conditional-and-loop-functions.html
+++ b/examples/conditional-and-loop-functions.html
@@ -3,7 +3,7 @@
   <head>
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-html-keyboard-response.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/data-add-properties.html
+++ b/examples/data-add-properties.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-image-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/data-as-function.html
+++ b/examples/data-as-function.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-image-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/data-from-timeline.html
+++ b/examples/data-from-timeline.html
@@ -5,7 +5,7 @@
 
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-image-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/data-from-url.html
+++ b/examples/data-from-url.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <script src="../jspsych.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body>
     <p>The URL variable should be logged to the console</p>

--- a/examples/demo-simple-rt-task.html
+++ b/examples/demo-simple-rt-task.html
@@ -5,7 +5,7 @@
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-html-keyboard-response.js"></script>
     <script src="../plugins/jspsych-image-keyboard-response.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/demos/demo_2.html
+++ b/examples/demos/demo_2.html
@@ -3,7 +3,7 @@
 <head>
 	<script src="../../jspsych.js"></script>
 	<script src="../../plugins/jspsych-image-keyboard-response.js"></script>
-	<link rel="stylesheet" href="../../css/jspsych.css"></link>
+	<link rel="stylesheet" href="../../css/jspsych.css">
 	<style>
 		img {
 			width: 300px;

--- a/examples/display-element-to-embed-experiment.html
+++ b/examples/display-element-to-embed-experiment.html
@@ -6,7 +6,7 @@
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-image-keyboard-response.js"></script>
   <script src="../plugins/jspsych-html-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     p { line-height: 1.5em; font-size: 18px; }
     img {

--- a/examples/end-active-node.html
+++ b/examples/end-active-node.html
@@ -6,7 +6,7 @@
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-html-keyboard-response.js"></script>
   <script src="../plugins/jspsych-image-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/end-experiment.html
+++ b/examples/end-experiment.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-image-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/exclusions.html
+++ b/examples/exclusions.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-html-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/jspsych-RDK.html
+++ b/examples/jspsych-RDK.html
@@ -3,7 +3,7 @@
 	<head>
 		<script src="../jspsych.js"></script>
 		<script src="../plugins/jspsych-rdk.js"></script>
-		<link rel="stylesheet" href="../css/jspsych.css"></link>
+		<link rel="stylesheet" href="../css/jspsych.css">
 	</head>
 	<body></body>
 	<script>

--- a/examples/jspsych-animation.html
+++ b/examples/jspsych-animation.html
@@ -3,7 +3,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-animation.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
 </head>
 <body></body>
 <script>

--- a/examples/jspsych-audio-button-response.html
+++ b/examples/jspsych-audio-button-response.html
@@ -4,7 +4,7 @@
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-audio-button-response.js"></script>
     <script src="../plugins/jspsych-html-button-response.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/jspsych-audio-keyboard-response.html
+++ b/examples/jspsych-audio-keyboard-response.html
@@ -4,7 +4,7 @@
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-audio-keyboard-response.js"></script>
   <script src="../plugins/jspsych-html-button-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
 </head>
 <body></body>
 <script>

--- a/examples/jspsych-audio-slider-response.html
+++ b/examples/jspsych-audio-slider-response.html
@@ -4,7 +4,7 @@
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-audio-slider-response.js"></script>
   <script src="../plugins/jspsych-html-button-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
 </head>
 <body></body>
 <script>

--- a/examples/jspsych-call-function.html
+++ b/examples/jspsych-call-function.html
@@ -3,7 +3,7 @@
   <head>
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-call-function.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/jspsych-categorize-animation.html
+++ b/examples/jspsych-categorize-animation.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-categorize-animation.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/jspsych-categorize-html.html
+++ b/examples/jspsych-categorize-html.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-categorize-html.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/jspsych-categorize-image.html
+++ b/examples/jspsych-categorize-image.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-categorize-image.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/jspsych-cloze.html
+++ b/examples/jspsych-cloze.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-cloze.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/jspsych-free-sort.html
+++ b/examples/jspsych-free-sort.html
@@ -3,7 +3,7 @@
   <head>
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-free-sort.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/jspsych-fullscreen.html
+++ b/examples/jspsych-fullscreen.html
@@ -6,7 +6,7 @@
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-fullscreen.js"></script>
   <script src="../plugins/jspsych-image-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/jspsych-html-button-response.html
+++ b/examples/jspsych-html-button-response.html
@@ -3,7 +3,7 @@
   <head>
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-html-button-response.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
     <style>
       img { width: 300px; }
     </style>

--- a/examples/jspsych-html-keyboard-response.html
+++ b/examples/jspsych-html-keyboard-response.html
@@ -3,7 +3,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-html-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
 </head>
 <body></body>
 <script>

--- a/examples/jspsych-html-slider-response.html
+++ b/examples/jspsych-html-slider-response.html
@@ -3,7 +3,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-html-slider-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/jspsych-iat.html
+++ b/examples/jspsych-iat.html
@@ -6,7 +6,7 @@
   <script src="../plugins/jspsych-iat-image.js"></script>
   <script src="../plugins/jspsych-iat-html.js"></script>
   <script src="../plugins/jspsych-html-keyboard-response.js"></script>
-  <link href="../css/jspsych.css" rel="stylesheet"></link>
+  <link href="../css/jspsych.css" rel="stylesheet">
 </head>
 <body>
 </body>

--- a/examples/jspsych-image-button-response.html
+++ b/examples/jspsych-image-button-response.html
@@ -3,7 +3,7 @@
   <head>
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-image-button-response.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
     <style>
       img { width: 300px; }
     </style>

--- a/examples/jspsych-image-keyboard-response.html
+++ b/examples/jspsych-image-keyboard-response.html
@@ -3,7 +3,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-image-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/jspsych-image-slider-response.html
+++ b/examples/jspsych-image-slider-response.html
@@ -3,7 +3,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-image-slider-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/jspsych-instructions.html
+++ b/examples/jspsych-instructions.html
@@ -3,7 +3,7 @@
   <head>
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-instructions.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/jspsych-reconstruction.html
+++ b/examples/jspsych-reconstruction.html
@@ -4,7 +4,7 @@
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-html-keyboard-response.js"></script>
     <script src="../plugins/jspsych-reconstruction.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/jspsych-resize.html
+++ b/examples/jspsych-resize.html
@@ -4,7 +4,7 @@
 	<script src="../jspsych.js"></script>
 	<script src="../plugins/jspsych-resize.js"></script>
 	<script src="../plugins/jspsych-image-keyboard-response.js"></script>
-	<link rel="stylesheet" href="../css/jspsych.css"></link>
+	<link rel="stylesheet" href="../css/jspsych.css">
 </head>
 <body>
 </body>

--- a/examples/jspsych-same-different-html.html
+++ b/examples/jspsych-same-different-html.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-same-different-html.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
 </head>
 <body></body>
 <script>

--- a/examples/jspsych-same-different-image.html
+++ b/examples/jspsych-same-different-image.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-same-different-image.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/jspsych-serial-reaction-time-mouse.html
+++ b/examples/jspsych-serial-reaction-time-mouse.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-serial-reaction-time-mouse.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
 </head>
 
 <body></body>

--- a/examples/jspsych-serial-reaction-time.html
+++ b/examples/jspsych-serial-reaction-time.html
@@ -5,7 +5,7 @@
 
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-serial-reaction-time.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
 </head>
 
 <script>

--- a/examples/jspsych-survey-likert.html
+++ b/examples/jspsych-survey-likert.html
@@ -4,7 +4,7 @@
 
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-survey-likert.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/jspsych-survey-multi-choice.html
+++ b/examples/jspsych-survey-multi-choice.html
@@ -3,7 +3,7 @@
   <head>
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-survey-multi-choice.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/jspsych-survey-multi-select.html
+++ b/examples/jspsych-survey-multi-select.html
@@ -6,7 +6,7 @@
   <title>Document</title>
   <script src="../jspsych.js" ></script>
   <script src="../plugins/jspsych-survey-multi-select.js" ></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
 </head>
 
 <body>

--- a/examples/jspsych-survey-text.html
+++ b/examples/jspsych-survey-text.html
@@ -4,7 +4,7 @@
 
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-survey-text.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/jspsych-video-button-response.html
+++ b/examples/jspsych-video-button-response.html
@@ -4,7 +4,7 @@
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-video-button-response.js"></script>
     <script src="../plugins/jspsych-html-button-response.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/jspsych-video-keyboard-response.html
+++ b/examples/jspsych-video-keyboard-response.html
@@ -4,7 +4,7 @@
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-video-keyboard-response.js"></script>
     <script src="../plugins/jspsych-html-button-response.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/jspsych-video-slider-response.html
+++ b/examples/jspsych-video-slider-response.html
@@ -4,7 +4,7 @@
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-video-slider-response.js"></script>
     <script src="../plugins/jspsych-html-button-response.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/jspsych-visual-search-circle.html
+++ b/examples/jspsych-visual-search-circle.html
@@ -7,7 +7,7 @@
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-html-keyboard-response.js"></script>
   <script src="../plugins/jspsych-visual-search-circle.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
 </head>
 <body></body>
 <script>

--- a/examples/jspsych-vsl-animate-occlusion.html
+++ b/examples/jspsych-vsl-animate-occlusion.html
@@ -6,7 +6,7 @@
   <script src="js/snap.svg-min.js"></script>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-vsl-animate-occlusion.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
 </head>
 <body></body>
 <script>

--- a/examples/jspsych-vsl-grid-scene.html
+++ b/examples/jspsych-vsl-grid-scene.html
@@ -4,7 +4,7 @@
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-vsl-grid-scene.js"></script>
     <script src="../plugins/jspsych-html-keyboard-response.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
 
   <script>

--- a/examples/lexical-decision.html
+++ b/examples/lexical-decision.html
@@ -6,7 +6,7 @@
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-html-keyboard-response.js"></script>
   <script src="../plugins/jspsych-html-button-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
   .stimulus { font-size: 32px; }
   </style>

--- a/examples/manual-preloading.html
+++ b/examples/manual-preloading.html
@@ -3,7 +3,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-image-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/pause-unpause.html
+++ b/examples/pause-unpause.html
@@ -4,7 +4,7 @@
 
     <script src="../jspsych.js"></script>
     <script src="../plugins/jspsych-html-keyboard-response.js"></script>
-    <link rel="stylesheet" href="../css/jspsych.css"></link>
+    <link rel="stylesheet" href="../css/jspsych.css">
   </head>
   <body></body>
   <script>

--- a/examples/progress-bar.html
+++ b/examples/progress-bar.html
@@ -4,7 +4,7 @@
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-image-keyboard-response.js"></script>
   <script src="../plugins/jspsych-html-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;

--- a/examples/timeline-variables-sampling.html
+++ b/examples/timeline-variables-sampling.html
@@ -4,7 +4,7 @@
 <head>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-html-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
   </style>
 </head>

--- a/examples/timeline-variables.html
+++ b/examples/timeline-variables.html
@@ -7,7 +7,7 @@
   <script src="../plugins/jspsych-image-keyboard-response.js"></script>
   <script src="../plugins/jspsych-audio-keyboard-response.js"></script>
   <script src="../plugins/jspsych-html-keyboard-response.js"></script>
-  <link rel="stylesheet" href="../css/jspsych.css"></link>
+  <link rel="stylesheet" href="../css/jspsych.css">
   <style>
     img {
       width: 300px;


### PR DESCRIPTION
In either [HTML5](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link) or [HTML4](https://www.w3.org/TR/html401/struct/links.html#h-12.3), the `<link>` tag should not have a closing tag. Of course, browsers are tolerant of this error, but since jsPsych has many people learning HTML for the first time, let's fix this?
