### PR TITLE
systematically saving stimulus and slider start position in all slider plugins

### DIFF
--- a/plugins/jspsych-audio-slider-response.js
+++ b/plugins/jspsych-audio-slider-response.js
@@ -181,7 +181,8 @@ jsPsych.plugins['audio-slider-response'] = (function() {
       // save data
       var trialdata = {
         "rt": response.rt,
-				"stimulus": trial.stimulus,
+        "stimulus": trial.stimulus,
+        "start": trial.start,
         "response": response.response
       };
 

--- a/plugins/jspsych-html-slider-response.js
+++ b/plugins/jspsych-html-slider-response.js
@@ -135,7 +135,7 @@ jsPsych.plugins['html-slider-response'] = (function() {
       rt: null,
       response: null
     };
-    
+
     if(trial.require_movement){
       display_element.querySelector('#jspsych-html-slider-response-response').addEventListener('change', function(){
         display_element.querySelector('#jspsych-html-slider-response-next').disabled = false;
@@ -163,8 +163,9 @@ jsPsych.plugins['html-slider-response'] = (function() {
       // save data
       var trialdata = {
         "rt": response.rt,
-        "response": response.response,
-        "stimulus": trial.stimulus
+        "stimulus": trial.stimulus,
+        "start": trial.start,
+        "response": response.response
       };
 
       display_element.innerHTML = '';

--- a/plugins/jspsych-image-slider-response.js
+++ b/plugins/jspsych-image-slider-response.js
@@ -198,6 +198,8 @@ jsPsych.plugins['image-slider-response'] = (function() {
       // save data
       var trialdata = {
         "rt": response.rt,
+        "stimulus": trial.stimulus,
+        "start": trial.start,
         "response": response.response
       };
 

--- a/plugins/jspsych-video-slider-response.js
+++ b/plugins/jspsych-video-slider-response.js
@@ -171,7 +171,7 @@ jsPsych.plugins["video-slider-response"] = (function() {
         }
         var type = file_name.substr(file_name.lastIndexOf('.') + 1);
         type = type.toLowerCase();
-        video_html+='<source src="' + file_name + '" type="video/'+type+'">';   
+        video_html+='<source src="' + file_name + '" type="video/'+type+'">';
       }
     }
     video_html += "</video>";
@@ -269,6 +269,7 @@ jsPsych.plugins["video-slider-response"] = (function() {
       var trial_data = {
         "rt": response.rt,
         "stimulus": trial.stimulus,
+        "start": trial.start,
         "response": response.response
       };
 


### PR DESCRIPTION
This fixes issue #689.

It also adds saving the starting position of the slider, which is useful when the start position is set to vary randomly from trial to trial. Saving the starting position is useful here to account for how "reliable" responses actually are. For instance, it is now possible to correlate responses with starting slider positions, with the expectation that their values should be uncorrelated.