### PR TITLE
Update package.json to reflect organization

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jodeleeuw/jsPsych.git"
+    "url": "git+https://github.com/jspsych/jsPsych.git"
   },
   "author": "Josh de Leeuw",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jodeleeuw/jsPsych/issues"
+    "url": "https://github.com/jspsych/jsPsych/issues"
   },
-  "homepage": "https://github.com/jodeleeuw/jsPsych#readme",
+  "homepage": "https://github.com/jspsych/jsPsych#readme",
   "devDependencies": {
     "jest": "^24.8"
   },


### PR DESCRIPTION
**Files affected**
 - `package.json`

**Changes**
The name of the remote repository was attached to the previous username. This change updates the package.json references to the remote Git URLs with the organization `jspsych`.

**Reason**
This change will improve `npm install` compatibility to allow for installation at a given branch or tag version. For instance, in order for the command `npm install git+https://github.com/jspsych/jsPsych#v6.1.0` to work successfully, it requires the proposed changes to be merged with the `master` branch.