### PR TITLE
Graceful failure on DataCollection.first and .last

### DIFF
--- a/jspsych.js
+++ b/jspsych.js
@@ -1130,20 +1130,28 @@ jsPsych.data = (function() {
     }
 
     data_collection.first = function(n){
-      if(typeof n=='undefined'){ n = 1 }
-      var out = [];
-      for(var i=0; i<n; i++){
-        out.push(trials[i]);
+      if (trials.length == 0) throw `No data recorded yet.`
+      if (typeof n == 'undefined') { n = 1 }
+      if (n > trials.length) {
+        throw `Please use a value for n that is fewer than ${trials.length}.`;
+      } else if (n < 1) {
+        throw `You must query with a positive nonzero integer. Please use a 
+               different value for n.`;
       }
+      var out = trials.slice(0, n);
       return DataCollection(out);
     }
 
-    data_collection.last = function(n){
-      if(typeof n=='undefined'){ n = 1 }
-      var out = [];
-      for(var i=trials.length-n; i<trials.length; i++){
-        out.push(trials[i]);
+    data_collection.last = function(n) {
+      if (trials.length == 0) throw `No data recorded yet.`
+      if (typeof n == 'undefined') { n = 1 }
+      if (n > trials.length) {
+        throw `Please use a value for n that is fewer than ${trials.length}.`;
+      } else if (n < 1) {
+        throw `You must query with a positive nonzero integer. Please use a 
+               different value for n.`;
       }
+      var out = trials.slice(trials.length - n, trials.length);
       return DataCollection(out);
     }
 

--- a/jspsych.js
+++ b/jspsych.js
@@ -1129,30 +1129,48 @@ jsPsych.data = (function() {
       }
     }
 
+    /**
+     * Queries the first n elements in a collection of trials.
+     *
+     * @param {number} n A positive integer of elements to return. A value of
+     *                   n that is less than 1 will throw an error.
+     *
+     * @return {Array} First n objects of a collection of trials. If fewer than
+     *                 n trials are available, the trials.length elements will
+     *                 be returned.
+     *
+     */
     data_collection.first = function(n){
-      if (trials.length == 0) throw `No data recorded yet.`
       if (typeof n == 'undefined') { n = 1 }
-      if (n > trials.length) {
-        throw `Please use a value for n that is fewer than ${trials.length}.`;
-      } else if (n < 1) {
+      if (n < 1) {
         throw `You must query with a positive nonzero integer. Please use a 
                different value for n.`;
       }
-      var out = trials.slice(0, n);
-      return DataCollection(out);
+      if (trials.length == 0) return DataCollection([]);
+      if (n > trials.length) n = trials.length;
+      return DataCollection(trials.slice(0, n));
     }
 
+    /**
+     * Queries the last n elements in a collection of trials.
+     *
+     * @param {number} n A positive integer of elements to return. A value of
+     *                   n that is less than 1 will throw an error.
+     *
+     * @return {Array} Last n objects of a collection of trials. If fewer than
+     *                 n trials are available, the trials.length elements will
+     *                 be returned.
+     *
+     */
     data_collection.last = function(n) {
-      if (trials.length == 0) throw `No data recorded yet.`
       if (typeof n == 'undefined') { n = 1 }
-      if (n > trials.length) {
-        throw `Please use a value for n that is fewer than ${trials.length}.`;
-      } else if (n < 1) {
+      if (n < 1) {
         throw `You must query with a positive nonzero integer. Please use a 
                different value for n.`;
       }
-      var out = trials.slice(trials.length - n, trials.length);
-      return DataCollection(out);
+      if (trials.length == 0) return DataCollection([]);
+      if (n > trials.length) n = trials.length;
+      return DataCollection(trials.slice(trials.length - n, trials.length));
     }
 
     data_collection.values = function(){


### PR DESCRIPTION
Reason:
- When n > number of trials, or nonpositive, failure caused crashing

Changes made:
- Update each .first and .last methods to return when n is within range,
  while throwing an error when it is not.
- Use Array.prototype.slice to create subarrays

Notes:
- Issue #751 and #748
- Unsure of precise goal for graceful failure. Should it throw an error
  create a dummy array of some length?