### PR TITLE
Instructions plugin changes

### DIFF
--- a/docs/plugins/jspsych-instructions.md
+++ b/docs/plugins/jspsych-instructions.md
@@ -2,10 +2,6 @@
 
 This plugin is for showing instructions to the subject. It allows subjects to navigate through multiple pages of instructions at their own pace, recording how long the subject spends on each page. Navigation can be done using the mouse or keyboard. Subjects can be allowed to navigate forwards and backwards through pages, if desired.
 
-## Parameters
-
-Parameters with a default value of *undefined* must be specified. Other parameters can be left unspecified if the default value is acceptable.
-
 Parameter | Type | Default Value | Description
 ----------|------|---------------|------------
 pages | array | *undefined* | Each element of the array is the content for a single page. Each page should be an HTML-formatted string.
@@ -16,7 +12,8 @@ allow_keys | boolean | true | If true, the subject can use keyboard keys to navi
 show_clickable_nav | boolean | false | If true, then a `Previous` and `Next` button will be displayed beneath the instructions. Subjects can click the buttons to navigate.
 button_label_previous | string | 'Previous' | The text that appears on the button to go backwards.
 button_label_next | string | 'Next' | The text that appears on the button to go forwards.
-
+show_page_number | boolean | false | If true, and clickable navigation is enabled, then Page x/y will be shown between the nav buttons.
+page_label | string | 'Page' | The text that appears before x/y pages displayed with show_page_number.
 
 ## Data Generated
 

--- a/docs/plugins/jspsych-instructions.md
+++ b/docs/plugins/jspsych-instructions.md
@@ -2,6 +2,10 @@
 
 This plugin is for showing instructions to the subject. It allows subjects to navigate through multiple pages of instructions at their own pace, recording how long the subject spends on each page. Navigation can be done using the mouse or keyboard. Subjects can be allowed to navigate forwards and backwards through pages, if desired.
 
+## Parameters
+
+Parameters with a default value of *undefined* must be specified. Other parameters can be left unspecified if the default value is acceptable.
+
 Parameter | Type | Default Value | Description
 ----------|------|---------------|------------
 pages | array | *undefined* | Each element of the array is the content for a single page. Each page should be an HTML-formatted string.
@@ -12,8 +16,7 @@ allow_keys | boolean | true | If true, the subject can use keyboard keys to navi
 show_clickable_nav | boolean | false | If true, then a `Previous` and `Next` button will be displayed beneath the instructions. Subjects can click the buttons to navigate.
 button_label_previous | string | 'Previous' | The text that appears on the button to go backwards.
 button_label_next | string | 'Next' | The text that appears on the button to go forwards.
-show_page_number | boolean | false | If true, and clickable navigation is enabled, then Page x/y will be shown between the nav buttons.
-page_label | string | 'Page' | The text that appears before x/y pages displayed with show_page_number.
+
 
 ## Data Generated
 

--- a/docs/plugins/jspsych-virtual-chin-rest.md
+++ b/docs/plugins/jspsych-virtual-chin-rest.md
@@ -1,0 +1,43 @@
+# jspsych-virtual-chin-rest plugin
+
+This plugin consist in two parts:
+
+To first calculate a participant’s display, participants are asked to place a credit card-sized card on the screen and adjust the slider on the screen to fit the credit card. That allows the researchers to calculate the pixel density on the monitor.
+
+To measure the user’s distance from his or her monitor, there is also a blind spot task. Testers are asked to focus on a black square on the screen with their right eye closed, while a red dot repeatedly sweeps from right to left. They must hit the spacebar on their keyboards whenever it appears that the red dot has disappeared. That allows researchers to determine the distance between the center of the black square and the center of the red dot when it disappears from eyesight and understand how far the participant is from the monitor.
+
+
+We would appreciate it if you cited this paper when you use the virtual-chin-rest plugin: 
+
+**Li, Q., Joo, S. J., Yeatman, J. D., & Reinecke, K. (2020). Controlling for Participants’ Viewing Distance in Large-Scale, Psychophysical Online Experiments Using a Virtual Chinrest. Scientific Reports, 10(1), 1-11. DOI: [10.1038/s41598-019-57204-1]**
+
+
+
+## Parameters
+
+Parameters can be left unspecified if the default value is acceptable.
+
+|Parameter|Type|Default Value| Descripton|
+|---------|----|-------------|-----------|
+
+
+## Data Generated
+
+In addition to the default data collected by all plugins, this plugin collects all parameter data described above and the following data for each trial.
+
+
+|Name|Type|Value|
+|----|----|-----|
+viewing_distance_cm|numeric|
+cardWidth_px| numeric
+screen_size_px| char
+
+## Example
+
+
+```javascript
+var chin = {   
+
+		type: 'virtual-chin'
+			
+    }

--- a/plugins/jspsych-instructions.js
+++ b/plugins/jspsych-instructions.js
@@ -63,6 +63,12 @@ jsPsych.plugins.instructions = (function() {
           default: false,
           description: 'If true, and clickable navigation is enabled, then Page x/y will be shown between the nav buttons.'
       },
+      page_label: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Page label',
+        default: 'Page',
+        description: 'The text that appears before x/y (current/total) pages displayed with show_page_number'
+      },      
       button_label_previous: {
         type: jsPsych.plugins.parameterType.STRING,
         pretty_name: 'Button label previous',
@@ -104,7 +110,7 @@ jsPsych.plugins.instructions = (function() {
       var pagenum_display = "";
       if(trial.show_page_number) {
           pagenum_display = "<span style='margin: 0 1em;' class='"+
-          "jspsych-instructions-pagenum'>Page "+(current_page+1)+"/"+trial.pages.length+"</span>";
+          "jspsych-instructions-pagenum'>"+ trial.page_label + ' ' +(current_page+1)+"/"+trial.pages.length+"</span>";
       }
      
       if (trial.show_clickable_nav) {

--- a/plugins/jspsych-instructions.js
+++ b/plugins/jspsych-instructions.js
@@ -63,6 +63,12 @@ jsPsych.plugins.instructions = (function() {
           default: false,
           description: 'If true, and clickable navigation is enabled, then Page x/y will be shown between the nav buttons.'
       },
+      page_label: {
+        type: jsPsych.plugins.parameterType.STRING,
+        pretty_name: 'Page label',
+        default: 'Page',
+        description: 'The text before x/y (current/total) pages displayed with show_page_number'
+      },      
       button_label_previous: {
         type: jsPsych.plugins.parameterType.STRING,
         pretty_name: 'Button label previous',
@@ -104,7 +110,7 @@ jsPsych.plugins.instructions = (function() {
       var pagenum_display = "";
       if(trial.show_page_number) {
           pagenum_display = "<span style='margin: 0 1em;' class='"+
-          "jspsych-instructions-pagenum'>Page "+(current_page+1)+"/"+trial.pages.length+"</span>";
+          "jspsych-instructions-pagenum'>"+ trial.page_label + ' ' +(current_page+1)+"/"+trial.pages.length+"</span>";
       }
      
       if (trial.show_clickable_nav) {

--- a/plugins/jspsych-instructions.js
+++ b/plugins/jspsych-instructions.js
@@ -63,12 +63,6 @@ jsPsych.plugins.instructions = (function() {
           default: false,
           description: 'If true, and clickable navigation is enabled, then Page x/y will be shown between the nav buttons.'
       },
-      page_label: {
-        type: jsPsych.plugins.parameterType.STRING,
-        pretty_name: 'Page label',
-        default: 'Page',
-        description: 'The text before x/y (current/total) pages displayed with show_page_number'
-      },      
       button_label_previous: {
         type: jsPsych.plugins.parameterType.STRING,
         pretty_name: 'Button label previous',
@@ -110,7 +104,7 @@ jsPsych.plugins.instructions = (function() {
       var pagenum_display = "";
       if(trial.show_page_number) {
           pagenum_display = "<span style='margin: 0 1em;' class='"+
-          "jspsych-instructions-pagenum'>"+ trial.page_label + ' ' +(current_page+1)+"/"+trial.pages.length+"</span>";
+          "jspsych-instructions-pagenum'>Page "+(current_page+1)+"/"+trial.pages.length+"</span>";
       }
      
       if (trial.show_clickable_nav) {

--- a/plugins/jspsych-virtual-chin-rest.js
+++ b/plugins/jspsych-virtual-chin-rest.js
@@ -1,6 +1,9 @@
 /*
- *  plugin based in  Qisheng Li 11/2019. /// https://github.com/QishengLi/virtual_chinrest
-    Modified by Gustavo Juantorena 08/2020
+ *  plugin for jsPsych based in Qisheng Li 11/2019. /// https://github.com/QishengLi/virtual_chinrest
+    
+    Modified by Gustavo Juantorena 08/2020 // https://github.com/GEJ1
+
+    Work in progress in jsPsych discussion: https://github.com/jspsych/jsPsych/discussions/975
  */
 
 jsPsych.plugins['virtual-chin'] = (function() {
@@ -23,12 +26,7 @@ jsPsych.plugins['virtual-chin'] = (function() {
         pretty_name: 'Pixels per unit',
         default: 100,
         description: 'After the scaling factor is applied, this many pixels will equal one unit of measurement.'
-      },
-      prompt_instructions: {
-        type: jsPsych.plugins.parameterType.STRING,
-        default: null,
-        description: 'Any content here will be displayed above card image.'
-      },
+      }
       // prompt_card: {
       //   type: jsPsych.plugins.parameterType.STRING,
       //   default: null,
@@ -112,7 +110,6 @@ jsPsych.plugins['virtual-chin'] = (function() {
 
   });
 
-
   //=============================
   //Ball Animation
 
@@ -194,28 +191,9 @@ jsPsych.plugins['virtual-chin'] = (function() {
 
               // You can then DO SOMETHING HERE TO PROCEED TO YOUR NEXT STEPS OF THE EXPERIMENT. For example, add a button to go to the next page.
               // display_element.innerHTML = `<p>"Press space bar to start the experiment.</p>`
-              display_element.innerHTML = 
-                
-              `<p style='font-size:180%;'>  Este experimento consta de dos tipos de ensayos: <br></p>
-              <p style='font-size:130%;'>
-              Los ensayos del primer tipo consisten en una serie de números del 1 al 20 rodeados cada
-              uno por un círculo.<br> Su objetivo será unir con un trazo continuo los puntos en orden creciente,<br> tratando de
-              evitar que los trazos se toquen.<br> Tendrá un límite de tiempo fijo para resolver cada ensayo.<br>
-              AL COMENZAR CADA ENSAYO VERÁ UNA CRUZ EN EL CENTRO DE LA PANTALLA,<br> CUANDO ESTA DESAPAREZCA Y VEA LOS CIRCULOS
-              DEBERÁ PRESIONAR EL BOTON IZQUIERDO DEL MOUSE (O SU PAD DE NOTEBOOK) <br>Y
-              MANTENERLO PRESIONADO HASTA TERMINARLO.<br> No levante el dedo del botón al menos que
-              hayas terminado el ensayo, o que este haya terminado por superar el tiempo límite.<br>
-              El otro tipo de ensayo consiste en una serie de números del 1 al 10 y letras de la A
-              a la J.<br> Su objetivo será unir con un trazo continuo los puntos de manera alternada (ejemplo 1-A-2-B-3-C,
-              etc).<br><br><br>
-  
-              Su objetivo será realizar la tarea SIN PASAR POR ENCIMA DE SU PROPIO TRAZO y lo más rápido posible.<br>
-              Los ensayos van a aparecer siempre alternadamente.<br><br>
-              
-              ¡Suerte y muchas gracias por participar! </p><br>
-              
-              <p style='font-size:200%;'>  Para comenzar por favor presione la barra espaciadora </p>
-              `
+              display_element.innerHTML =
+                "<p style='font-size:160%;'> When you are ready, please press space bar to start the experiment.</p>" +
+                `<p style='font-size:160%;'>  Your viewing distance is about ${dist.toString()} cm </p>`
 
               return trial_data.viewing_distance_cm;
           }
@@ -234,35 +212,37 @@ jsPsych.plugins['virtual-chin'] = (function() {
 
       // You can write functions here that live only in the scope of plugin.trial
       function show_stimulus(){
-        display_element.innerHTML = `<p>Por favor repetí la medición de la tarjeta,pero esta vez utilizando la barra deslizante.</p>`    
+        display_element.innerHTML = `<p>Please use any credit card that you have available (it can also be a grocery store membership 
+          card, your drivers license, or anything that is of the same format), hold it onto the screen, and adjust the slider below to its size.</p>`    
 
 
-          var html = "<body><div id='content'><div id='page-size'><br><br><br><br><br><br>";
+          var html = "<body><div id='content'><div id='page-size'>";
           // html += "<h3> Let’s find out what your monitor size is (click to go into <div onclick='fullScreen(); registerClick();' style='display:inline; cursor:pointer; color: red'><em><u>full screen mode</u></em></div>).</h2>";
           
-          html += "<p>Por favor repita la medición de la misma tarjeta, pero esta vez utilizando la barra deslizante.</p>";   
-          
-          html += "<b style='font-style: italic'>Asegúrese de poner la tarjeta sobre la pantalla.</b>";
+          html += "<p>Please use any credit card that you have available (it can also be a grocery store membership card, your drivers license, or anything that is of the same format), hold it onto the screen, and adjust the slider below to its size.</p>";   
+          html += "<p>(If you don't have access to a real card, you can use a ruler to measure image width to 3.37inch or 85.6mm, or make your best guess!)</p>";
+          html += "<b style='font-style: italic'>Make sure you put the card onto your screen.</b>";
           html += '<br><div id="container">';
           html += "<div id='slider'></div>";
           html += '<br> <img id="card" src="card.png" style="width: 50%"><br><br>';
-          html +='<button id="btnBlindSpot" class="btn btn-primary">Presione aquí cuando termine!</button></div></div>';
+          html +='<button id="btnBlindSpot" class="btn btn-primary">Click here when you are done!</button></div></div>';
 
         
           html += '<div id="blind-spot" style="visibility: hidden">';
           html += '<!-- <h2 class="bolded-blue">Task 2: Where’s your blind spot?</h2> -->';
-          html += "<h3>Ahora vamos a estimar su distancia a la pantalla.</h3>";
+          html += "<h3>Now, let's quickly test how far away you are sitting.</h3>";
+          html += "<p>You might know that vision tests at a doctor's practice often involve chinrests; the doctor basically asks you to sit away from a screen in a specific distance. We do this here with a 'virtual chinrest'.</p>";
           
-          html += '<h3>Instrucciones</h3>';
-          html += '<p>1. Coloque su dedo índice en la <b>barra espaciadora</b> </p>';
-          html += '<p>2. Cierre su ojo derecho. <em> (Tip:Quizá le resulte más fácil tapándolo con su mano!)</em></p>';
-          html += '<p>3. Usando su ojo izquierdo, haga foco en el cuadrado negro.</p>';
-          html += '<p>4. Presione el botón de abajo para iniciar la animación de la pelotita roja. Esa <b style="color: red">pelotita roja</b> va a desaparecer de su vista en algún momento. Ni bien la deje de ver (siempre enfocando en el cuadrado negro) presione una vez la barra lo más rápidamente posible.</p><br>';
-          html += '<p>Por favor repita el proceso <b>cinco</b> veces. Mantenga su ojo derecho cerrado y presione la barra espaciadora lo más rápidamente posible!</p><br>';
-          html += '<button class="btn btn-primary" id="start" ">Empezar</button>';
+          html += '<h3>Instructions</h3>';
+          html += '<p>1. Put your finger on <b>space bar</b> on the keyboard.</p>';
+          html += '<p>2. Close your right eye. <em>(Tips: it might be easier to cover your right eye by hand!)</em></p>';
+          html += '<p>3. Using your left eye, focus on the black square.</p>';
+          html += '<p>4. Click the button below to start the animation of the red ball. The <b style="color: red">red ball</b> will disappear as it moves from right to left. Press the Space key as soon as the ball disappears from your eye sight.</p><br>';
+          html += '<p>Please do it <b>five</b> times. Keep your right eye closed and hit the Space key fast!</p><br>';
+          html += '<button class="btn btn-primary" id="start" ">Start</button>';
 
           html += '<div id="svgDiv" style="width:1000px;height:200px;"></div>';
-          html +=  "Presioná la barra <div id='click' style='display:inline; color: red; font-weight: bold'>5</div> veces más!</div>";
+          html +=  "Hit 'space' <div id='click' style='display:inline; color: red; font-weight: bold'>5</div> more times!</div>";
 
 
       display_element.innerHTML = html; //
@@ -316,7 +296,7 @@ jsPsych.plugins['virtual-chin'] = (function() {
       }
 
       function end_trial(){
-        document.getElementsByClassName("jspsych-content-wrapper")[0].style.backgroundColor = 'gray'; //Background color
+        // document.getElementsByClassName("jspsych-content-wrapper")[0].style.backgroundColor = 'gray'; //Background color
         // trial_data.viewingDistance=   JSON.stringify(viewingDistance); // best practice for saving in jsPsych. It is a JSON instead of array.
         jsPsych.finishTrial(trial_data); // ends trial and save the data
         display_element.innerHTML = ' '; // clear the display

--- a/plugins/jspsych-virtual-chin-rest.js
+++ b/plugins/jspsych-virtual-chin-rest.js
@@ -40,13 +40,27 @@ jsPsych.plugins['virtual-chin'] = (function() {
     }
   }
   
+
   plugin.trial = function(display_element, trial) {
    
+    // Get screen size
+    var w = window.innerWidth;
+    var h = window.innerHeight;
+
+    const screen_size_px = []
+    screen_size_px.push(w)
+    screen_size_px.push('x')
+    screen_size_px.push(h)
+
+    
     // data saving
     var trial_data = { //I need to modify this in order to save important data
       'viewing_distance_cm': trial.viewing_distance_cm,
-      'cardWidth_px': trial.cardWidth_px
+      'cardWidth_px': trial.cardWidth_px,
+      'screen_size_px': trial.screen_size_px
     };
+
+    trial_data.screen_size_px = screen_size_px
 
   
   //Store all the configuration data in variable 'data'
@@ -71,11 +85,10 @@ jsPsych.plugins['virtual-chin'] = (function() {
 
   }( window.distanceSetup = window.distanceSetup || {}, jQuery));
 
-
+  
   function getCardWidth() {
       var cardWidthPx = $('#card').width();
       data["cardWidthPx"] = distanceSetup.round(cardWidthPx,2);
-      console.log(cardWidthPx)
 
       trial_data.cardWidth_px = cardWidthPx // add to trial_data
 
@@ -93,7 +106,6 @@ jsPsych.plugins['virtual-chin'] = (function() {
 
   };
 
-
   $( function() {
       $( "#slider" ).slider({value:"50"});
   } );
@@ -109,6 +121,7 @@ jsPsych.plugins['virtual-chin'] = (function() {
       });
 
   });
+
 
   //=============================
   //Ball Animation
@@ -150,6 +163,7 @@ jsPsych.plugins['virtual-chin'] = (function() {
   function recordPosition(event, angle=13.5) {
       // angle: define horizontal blind spot entry point position in degrees.
       if (event.keyCode == '32') { //Press "Space"
+          
 
           data["ballPosition"].push(distanceSetup.round((ball.cx() + moveX),2));
           var sum = data["ballPosition"].reduce((a, b) => a + b, 0);
@@ -157,7 +171,6 @@ jsPsych.plugins['virtual-chin'] = (function() {
           data["avgBallPos"] = distanceSetup.round(sum/ballPosLen, 2);
           var ball_sqr_distance = (data["squarePosition"]-data["avgBallPos"])/data["px2mm"];
           var viewDistance = ball_sqr_distance/Math.radians(angle)
-          console.log(Math.radians(angle))
           data["viewDistance_mm"] = distanceSetup.round(viewDistance, 2);
 
           //counter and stop
@@ -165,36 +178,29 @@ jsPsych.plugins['virtual-chin'] = (function() {
           counter = counter - 1;
           $('#click').text(Math.max(counter, 0));
           if (counter <= 0) {
-
               ball.stop();
 
               // Disable space key
               $('html').bind('keydown', function(e)
               {
-                if (e.keyCode == 32) {return false;} //32 is spacebar
+                if (e.keyCode == 32)  {return false;} //32 is spacebar I CHANGE THAT
               });
 
-              // // Display data
-              // $('#info').css("visibility", "visible");
-              // $('#info-h').append(data["viewDistance_mm"]/10)
+              // Display data
+              $('#info').css("visibility", "visible");
+              $('#info-h').append(data["viewDistance_mm"]/10)
 
 
               //Estimated viewing distance in centimeters
               trial_data.viewing_distance_cm = (data["viewDistance_mm"]/10); // add to trial_data
 
-              console.log(data["viewDistance_mm"]/10);
 
               dist = Math.round(data["viewDistance_mm"]/10)
 
               // The trial must end 
-              end_trial();
-
-              // You can then DO SOMETHING HERE TO PROCEED TO YOUR NEXT STEPS OF THE EXPERIMENT. For example, add a button to go to the next page.
-              // display_element.innerHTML = `<p>"Press space bar to start the experiment.</p>`
-              display_element.innerHTML =
-                "<p style='font-size:160%;'> When you are ready, please press space bar to start the experiment.</p>" +
-                `<p style='font-size:160%;'>  Your viewing distance is about ${dist.toString()} cm </p>`
-
+              end_trial()
+             
+              
               return trial_data.viewing_distance_cm;
           }
 
@@ -212,11 +218,10 @@ jsPsych.plugins['virtual-chin'] = (function() {
 
       // You can write functions here that live only in the scope of plugin.trial
       function show_stimulus(){
-        display_element.innerHTML = `<p>Please use any credit card that you have available (it can also be a grocery store membership 
-          card, your drivers license, or anything that is of the same format), hold it onto the screen, and adjust the slider below to its size.</p>`    
 
+          // create html for display
 
-          var html = "<body><div id='content'><div id='page-size'>";
+          var html = "<body><div id='content'><div id='page-size'><br><br><br><br><br><br>";
           // html += "<h3> Let’s find out what your monitor size is (click to go into <div onclick='fullScreen(); registerClick();' style='display:inline; cursor:pointer; color: red'><em><u>full screen mode</u></em></div>).</h2>";
           
           html += "<p>Please use any credit card that you have available (it can also be a grocery store membership card, your drivers license, or anything that is of the same format), hold it onto the screen, and adjust the slider below to its size.</p>";   
@@ -245,16 +250,20 @@ jsPsych.plugins['virtual-chin'] = (function() {
           html +=  "Hit 'space' <div id='click' style='display:inline; color: red; font-weight: bold'>5</div> more times!</div>";
 
 
-      display_element.innerHTML = html; //
+      // render
+      display_element.innerHTML = html; 
+
+      
+      //Event listeners for buttons
+
       document.getElementById("btnBlindSpot").addEventListener('click', function() {
-        console.log('presionaste el boton 1');
         configureBlindSpot();
       });
 
       document.getElementById("start").addEventListener('click', function() {
-        console.log('presionaste el boton 2');
         animateBall(); 
       });
+
 
         jsPsych.pluginAPI.getKeyboardResponse({ 
           callback_function: after_response,                           // we need to create after_response
@@ -264,42 +273,19 @@ jsPsych.plugins['virtual-chin'] = (function() {
           allow_held_key: true                                       // false for a new key pressing in order to get a new response  
         }); 
       }
-                  
-              //     <div id="container">
-              //         <div id="slider"></div>
-              //         <br>
-              //         <img id="card" src="card.png" style="width: 50%">
-              //         <br><br>
-              //         <button class="btn btn-primary" onclick="configureBlindSpot()">Click here when you are done!</button>
-              //     </div>
-              // </div>
-      
+       
 
-
-       // scales the stimulus
-    //     var scale_factor;
-    //     var final_height_px, final_width_px;
-    //     final_width_px = trial.cardWidth_px;
-    //     function scale() {
-    //       final_width_px = scale_div.offsetWidth;
-    //       //final_height_px = scale_div.offsetHeight;
-
-    //       var pixels_unit_screen = final_width_px / trial.item_width;
-
-    //       scale_factor = pixels_unit_screen / trial.pixels_per_unit;
-    //       document.getElementById("jspsych-content").style.transform = "scale(" + scale_factor + ")";
-    // };
       function after_response(response_info){
         // rt.push(response_info.rt); // response time of the key
-        // scale() // Esto lo agregue pero no creo que quede
         end_trial();
       }
 
       function end_trial(){
-        // document.getElementsByClassName("jspsych-content-wrapper")[0].style.backgroundColor = 'gray'; //Background color
-        // trial_data.viewingDistance=   JSON.stringify(viewingDistance); // best practice for saving in jsPsych. It is a JSON instead of array.
         jsPsych.finishTrial(trial_data); // ends trial and save the data
-        display_element.innerHTML = ' '; // clear the display
+        // display_element.innerHTML = ' '; // clear the display
+
+        jsPsych.pluginAPI.cancelAllKeyboardResponses();
+        
 
       }
       show_stimulus();
@@ -308,5 +294,3 @@ jsPsych.plugins['virtual-chin'] = (function() {
 
     return plugin;
   })();
-
-

--- a/plugins/jspsych-virtual-chin-rest.js
+++ b/plugins/jspsych-virtual-chin-rest.js
@@ -1,0 +1,332 @@
+/*
+ *  plugin based in  Qisheng Li 11/2019. /// https://github.com/QishengLi/virtual_chinrest
+    Modified by Gustavo Juantorena 08/2020
+ */
+
+jsPsych.plugins['virtual-chin'] = (function() {
+
+  var plugin = {};
+
+  plugin.info = {
+    name: "virtual-chin", 
+    parameters: {
+      viewing_distance_cm: {
+        type: jsPsych.plugins.parameterType.INT,
+        default: 0
+      },
+      cardWidth_px: {
+        type: jsPsych.plugins.parameterType.INT,
+        default: 0
+      },
+      pixels_per_unit: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Pixels per unit',
+        default: 100,
+        description: 'After the scaling factor is applied, this many pixels will equal one unit of measurement.'
+      },
+      prompt_instructions: {
+        type: jsPsych.plugins.parameterType.STRING,
+        default: null,
+        description: 'Any content here will be displayed above card image.'
+      },
+      // prompt_card: {
+      //   type: jsPsych.plugins.parameterType.STRING,
+      //   default: null,
+      //   description: 'Any content here will be displayed above card image.'
+      // },
+      // prompt_blindspot: {
+      //   type: jsPsych.plugins.parameterType.STRING,
+      //   default: null,
+      //   description: 'Any content here will be displayed below the stimulus.'
+      // }
+    }
+  }
+  
+  plugin.trial = function(display_element, trial) {
+   
+    // data saving
+    var trial_data = { //I need to modify this in order to save important data
+      'viewing_distance_cm': trial.viewing_distance_cm,
+      'cardWidth_px': trial.cardWidth_px
+    };
+
+  
+  //Store all the configuration data in variable 'data'
+  var data = {"dataType":"configurationData"};
+      
+      data["ballPosition"] = [];
+
+      data["sliderClicked"] = false;
+
+  (function ( distanceSetup, $ ) {  // jQuery short-hand for $(document).ready(function() { ... });
+
+      distanceSetup.round = function(value, decimals) {
+          return Number(Math.round(value+'e'+decimals)+'e-'+decimals);
+      };
+
+      distanceSetup.px2mm = function(cardImageWidth) {
+          const cardWidth = 85.6; //card dimension: 85.60 × 53.98 mm (3.370 × 2.125 in)
+          var px2mm = cardImageWidth/cardWidth;
+          data["px2mm"] = distanceSetup.round(px2mm, 2);
+          return px2mm; 
+      };
+
+  }( window.distanceSetup = window.distanceSetup || {}, jQuery));
+
+
+  function getCardWidth() {
+      var cardWidthPx = $('#card').width();
+      data["cardWidthPx"] = distanceSetup.round(cardWidthPx,2);
+      console.log(cardWidthPx)
+
+      trial_data.cardWidth_px = cardWidthPx // add to trial_data
+
+      return cardWidthPx
+  }
+
+
+  function configureBlindSpot() {
+
+      drawBall();
+      $('#page-size').remove();
+      $('#blind-spot').css({'visibility':'visible'});
+      // $(document).on('keydown', recordPosition);
+      $(document).on('keydown', recordPosition);
+
+  };
+
+
+  $( function() {
+      $( "#slider" ).slider({value:"50"});
+  } );
+
+  $(document).ready(function() {
+      $( "#slider" ).on("slide", function (event, ui) {
+          var cardWidth = ui.value + "%";
+          $("#card").css({"width":cardWidth});
+      });
+
+      $('#slider').on('slidechange', function(event, ui){
+          data["sliderClicked"] = true;
+      });
+
+  });
+
+
+  //=============================
+  //Ball Animation
+
+  function drawBall(pos=180){
+      // pos: define where the fixation square should be.
+      var mySVG = SVG("svgDiv");
+      const cardWidthPx = getCardWidth()
+      const rectX = distanceSetup.px2mm(cardWidthPx)*pos;
+      
+      const ballX = rectX*0.6 // define where the ball is
+      var ball = mySVG.circle(30).move(ballX, 50).fill("#f00"); 
+      window.ball = ball;
+      var square = mySVG.rect(30, 30).move(Math.min(rectX - 50, 950), 50); //square position
+      data["squarePosition"] = distanceSetup.round(square.cx(),2);
+      data['rectX'] = rectX
+      data['ballX'] = ballX
+  };
+
+
+  function animateBall(){
+      ball.animate(7000).during(
+          function(pos){
+              moveX = - pos*data['ballX'];
+              window.moveX = moveX;
+              moveY = 0;
+              ball.attr({transform:"translate("+moveX+","+moveY+")"});
+
+          }
+      ).loop(true, false).
+      after(function(){
+          animateBall();
+      });
+
+      //disbale the button after clicked once.
+      $("#start").attr("disabled", true);
+  };
+
+  function recordPosition(event, angle=13.5) {
+      // angle: define horizontal blind spot entry point position in degrees.
+      if (event.keyCode == '32') { //Press "Space"
+
+          data["ballPosition"].push(distanceSetup.round((ball.cx() + moveX),2));
+          var sum = data["ballPosition"].reduce((a, b) => a + b, 0);
+          var ballPosLen = data["ballPosition"].length;
+          data["avgBallPos"] = distanceSetup.round(sum/ballPosLen, 2);
+          var ball_sqr_distance = (data["squarePosition"]-data["avgBallPos"])/data["px2mm"];
+          var viewDistance = ball_sqr_distance/Math.radians(angle)
+          console.log(Math.radians(angle))
+          data["viewDistance_mm"] = distanceSetup.round(viewDistance, 2);
+
+          //counter and stop
+          var counter = Number($('#click').text());
+          counter = counter - 1;
+          $('#click').text(Math.max(counter, 0));
+          if (counter <= 0) {
+
+              ball.stop();
+
+              // Disable space key
+              $('html').bind('keydown', function(e)
+              {
+                if (e.keyCode == 32) {return false;} //32 is spacebar
+              });
+
+              // // Display data
+              // $('#info').css("visibility", "visible");
+              // $('#info-h').append(data["viewDistance_mm"]/10)
+
+
+              //Estimated viewing distance in centimeters
+              trial_data.viewing_distance_cm = (data["viewDistance_mm"]/10); // add to trial_data
+
+              console.log(data["viewDistance_mm"]/10);
+
+              dist = Math.round(data["viewDistance_mm"]/10)
+
+              // The trial must end 
+              end_trial();
+
+              // You can then DO SOMETHING HERE TO PROCEED TO YOUR NEXT STEPS OF THE EXPERIMENT. For example, add a button to go to the next page.
+              // display_element.innerHTML = `<p>"Press space bar to start the experiment.</p>`
+              display_element.innerHTML = 
+                
+              `<p style='font-size:180%;'>  Este experimento consta de dos tipos de ensayos: <br></p>
+              <p style='font-size:130%;'>
+              Los ensayos del primer tipo consisten en una serie de números del 1 al 20 rodeados cada
+              uno por un círculo.<br> Su objetivo será unir con un trazo continuo los puntos en orden creciente,<br> tratando de
+              evitar que los trazos se toquen.<br> Tendrá un límite de tiempo fijo para resolver cada ensayo.<br>
+              AL COMENZAR CADA ENSAYO VERÁ UNA CRUZ EN EL CENTRO DE LA PANTALLA,<br> CUANDO ESTA DESAPAREZCA Y VEA LOS CIRCULOS
+              DEBERÁ PRESIONAR EL BOTON IZQUIERDO DEL MOUSE (O SU PAD DE NOTEBOOK) <br>Y
+              MANTENERLO PRESIONADO HASTA TERMINARLO.<br> No levante el dedo del botón al menos que
+              hayas terminado el ensayo, o que este haya terminado por superar el tiempo límite.<br>
+              El otro tipo de ensayo consiste en una serie de números del 1 al 10 y letras de la A
+              a la J.<br> Su objetivo será unir con un trazo continuo los puntos de manera alternada (ejemplo 1-A-2-B-3-C,
+              etc).<br><br><br>
+  
+              Su objetivo será realizar la tarea SIN PASAR POR ENCIMA DE SU PROPIO TRAZO y lo más rápido posible.<br>
+              Los ensayos van a aparecer siempre alternadamente.<br><br>
+              
+              ¡Suerte y muchas gracias por participar! </p><br>
+              
+              <p style='font-size:200%;'>  Para comenzar por favor presione la barra espaciadora </p>
+              `
+
+              return trial_data.viewing_distance_cm;
+          }
+
+          ball.stop();
+          animateBall();
+      }
+  }
+
+  //helper function for radians
+  // Converts from degrees to radians.
+  Math.radians = function(degrees) {
+    return degrees * Math.PI / 180;
+  };
+
+
+      // You can write functions here that live only in the scope of plugin.trial
+      function show_stimulus(){
+        display_element.innerHTML = `<p>Por favor repetí la medición de la tarjeta,pero esta vez utilizando la barra deslizante.</p>`    
+
+
+          var html = "<body><div id='content'><div id='page-size'><br><br><br><br><br><br>";
+          // html += "<h3> Let’s find out what your monitor size is (click to go into <div onclick='fullScreen(); registerClick();' style='display:inline; cursor:pointer; color: red'><em><u>full screen mode</u></em></div>).</h2>";
+          
+          html += "<p>Por favor repita la medición de la misma tarjeta, pero esta vez utilizando la barra deslizante.</p>";   
+          
+          html += "<b style='font-style: italic'>Asegúrese de poner la tarjeta sobre la pantalla.</b>";
+          html += '<br><div id="container">';
+          html += "<div id='slider'></div>";
+          html += '<br> <img id="card" src="card.png" style="width: 50%"><br><br>';
+          html +='<button id="btnBlindSpot" class="btn btn-primary">Presione aquí cuando termine!</button></div></div>';
+
+        
+          html += '<div id="blind-spot" style="visibility: hidden">';
+          html += '<!-- <h2 class="bolded-blue">Task 2: Where’s your blind spot?</h2> -->';
+          html += "<h3>Ahora vamos a estimar su distancia a la pantalla.</h3>";
+          
+          html += '<h3>Instrucciones</h3>';
+          html += '<p>1. Coloque su dedo índice en la <b>barra espaciadora</b> </p>';
+          html += '<p>2. Cierre su ojo derecho. <em> (Tip:Quizá le resulte más fácil tapándolo con su mano!)</em></p>';
+          html += '<p>3. Usando su ojo izquierdo, haga foco en el cuadrado negro.</p>';
+          html += '<p>4. Presione el botón de abajo para iniciar la animación de la pelotita roja. Esa <b style="color: red">pelotita roja</b> va a desaparecer de su vista en algún momento. Ni bien la deje de ver (siempre enfocando en el cuadrado negro) presione una vez la barra lo más rápidamente posible.</p><br>';
+          html += '<p>Por favor repita el proceso <b>cinco</b> veces. Mantenga su ojo derecho cerrado y presione la barra espaciadora lo más rápidamente posible!</p><br>';
+          html += '<button class="btn btn-primary" id="start" ">Empezar</button>';
+
+          html += '<div id="svgDiv" style="width:1000px;height:200px;"></div>';
+          html +=  "Presioná la barra <div id='click' style='display:inline; color: red; font-weight: bold'>5</div> veces más!</div>";
+
+
+      display_element.innerHTML = html; //
+      document.getElementById("btnBlindSpot").addEventListener('click', function() {
+        console.log('presionaste el boton 1');
+        configureBlindSpot();
+      });
+
+      document.getElementById("start").addEventListener('click', function() {
+        console.log('presionaste el boton 2');
+        animateBall(); 
+      });
+
+        jsPsych.pluginAPI.getKeyboardResponse({ 
+          callback_function: after_response,                           // we need to create after_response
+          valid_responses: [trial.key],                             // valid_responses expects an array
+          rt_method: 'performance',                                   // This is only relevant for RT in audio stimuli
+          persist: false,                                             // true if you want to listen to more than one key
+          allow_held_key: true                                       // false for a new key pressing in order to get a new response  
+        }); 
+      }
+                  
+              //     <div id="container">
+              //         <div id="slider"></div>
+              //         <br>
+              //         <img id="card" src="card.png" style="width: 50%">
+              //         <br><br>
+              //         <button class="btn btn-primary" onclick="configureBlindSpot()">Click here when you are done!</button>
+              //     </div>
+              // </div>
+      
+
+
+       // scales the stimulus
+    //     var scale_factor;
+    //     var final_height_px, final_width_px;
+    //     final_width_px = trial.cardWidth_px;
+    //     function scale() {
+    //       final_width_px = scale_div.offsetWidth;
+    //       //final_height_px = scale_div.offsetHeight;
+
+    //       var pixels_unit_screen = final_width_px / trial.item_width;
+
+    //       scale_factor = pixels_unit_screen / trial.pixels_per_unit;
+    //       document.getElementById("jspsych-content").style.transform = "scale(" + scale_factor + ")";
+    // };
+      function after_response(response_info){
+        // rt.push(response_info.rt); // response time of the key
+        // scale() // Esto lo agregue pero no creo que quede
+        end_trial();
+      }
+
+      function end_trial(){
+        document.getElementsByClassName("jspsych-content-wrapper")[0].style.backgroundColor = 'gray'; //Background color
+        // trial_data.viewingDistance=   JSON.stringify(viewingDistance); // best practice for saving in jsPsych. It is a JSON instead of array.
+        jsPsych.finishTrial(trial_data); // ends trial and save the data
+        display_element.innerHTML = ' '; // clear the display
+
+      }
+      show_stimulus();
+
+    };
+
+    return plugin;
+  })();
+
+


### PR DESCRIPTION
I found that jspsych-instructions plugin not allowed to change the word "page" before the x/y in show_page_number. This is a problema if you want to made an experiment in non english language. So I added a parameter ' page_label ' in plugin.info where everyone can change the text before x/y.

Also changed the documentation in two parts:

1. New Parameter 'page_label'.
2. The existing parameter 'show_page_number' does not appear in the documentation, so I added it.

(sorry if I adding commits from the other pull request, i'm pretty new using pull requests)