### PR TITLE
Fixes errors in HTML5 audio event names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Documentation is available at [docs.jspsych.org](http://docs.jspsych.org).
 Need help?
 ----------
 
-For questions about using the library, please post to the [jsPsych e-mail list](https://groups.google.com/forum/#!forum/jspsych). This creates a public archive of questions and solutions.
+For questions about using the library, please use the [Discussions forum](https://github.com/jspsych/jsPsych/discussions).
 
 Contributing
 ------------

--- a/jspsych.js
+++ b/jspsych.js
@@ -2328,14 +2328,13 @@ jsPsych.pluginAPI = (function() {
     function load_audio_file_html5audio(source, count){
       count = count || 1;
       var audio = new Audio();
-      audio.addEventListener('canplaythrough', function handleCanPlayThrough(){
+      audio.addEventListener('canplaythrough', function(){
         audio_buffers[source] = audio;
         n_loaded++;
         loadfn(n_loaded);
         if(n_loaded == files.length){
           finishfn();
         }
-        this.removeEventListener('canplaythrough', handleCanPlayThrough);
       });
       audio.addEventListener('error', function(){
         if(count < jsPsych.initSettings().max_preload_attempts){

--- a/jspsych.js
+++ b/jspsych.js
@@ -2337,7 +2337,7 @@ jsPsych.pluginAPI = (function() {
         }
         this.removeEventListener('canplaythrough', handleCanPlayThrough);
       });
-      audio.addEventListener('onerror', function(){
+      audio.addEventListener('error', function(){
         if(count < jsPsych.initSettings().max_preload_attempts){
           setTimeout(function(){
             load_audio_file_html5audio(source, count+1)
@@ -2346,7 +2346,7 @@ jsPsych.pluginAPI = (function() {
           jsPsych.loadFail();
         }
       });
-      audio.addEventListener('onstalled', function(){
+      audio.addEventListener('stalled', function(){
         if(count < jsPsych.initSettings().max_preload_attempts){
           setTimeout(function(){
             load_audio_file_html5audio(source, count+1)
@@ -2355,7 +2355,7 @@ jsPsych.pluginAPI = (function() {
           jsPsych.loadFail();
         }
       });
-      audio.addEventListener('onabort', function(){
+      audio.addEventListener('abort', function(){
         if(count < jsPsych.initSettings().max_preload_attempts){
           setTimeout(function(){
             load_audio_file_html5audio(source, count+1)

--- a/jspsych.js
+++ b/jspsych.js
@@ -2328,13 +2328,14 @@ jsPsych.pluginAPI = (function() {
     function load_audio_file_html5audio(source, count){
       count = count || 1;
       var audio = new Audio();
-      audio.addEventListener('canplaythrough', function(){
+      audio.addEventListener('canplaythrough', function handleCanPlayThrough(){
         audio_buffers[source] = audio;
         n_loaded++;
         loadfn(n_loaded);
         if(n_loaded == files.length){
           finishfn();
         }
+        this.removeEventListener('canplaythrough', handleCanPlayThrough);
       });
       audio.addEventListener('onerror', function(){
         if(count < jsPsych.initSettings().max_preload_attempts){


### PR DESCRIPTION
While working on #1115 I noticed some incorrect event names used for adding event listeners to HTML5 audio in the preloading function `load_audio_file_html5audio`. Using `addEventListener`, the names should be `error`, `stalled` and `abort` (without the 'on' prefix). As a result, these event listeners were never successfully added to the audio. 

I tested the audio's `error` event using an incorrect file name. Before the change made in this PR, the GET request only occurs once, produces a console error, and the progress bar freezes. After `max_load_time` is reached, the "Experiment failed to load" message is shown.

![audio_loading_err_old](https://user-images.githubusercontent.com/9041788/95803909-32281180-0cb6-11eb-91e0-3757b2392b9e.PNG)

After the change in this PR, the GET requests continue until `max_preload_attempts` is reached, then the "Experiment failed to load" message is shown. 

![audio_loading_err_new](https://user-images.githubusercontent.com/9041788/95804035-7e735180-0cb6-11eb-8e26-567344eb3451.PNG)

@jodeleeuw is this the intended behavior for an audio preloading error? I wasn't able to test the impact on `stalled` and `abort` events because I don't know how to trigger these.