### PR TITLE
Fix stimulus parameter naming in video response plugins

### DIFF
--- a/plugins/jspsych-video-button-response.js
+++ b/plugins/jspsych-video-button-response.js
@@ -12,7 +12,7 @@ jsPsych.plugins["video-button-response"] = (function() {
 
   var plugin = {};
 
-  jsPsych.pluginAPI.registerPreload('video-button-response', 'stimulus', 'video');
+  jsPsych.pluginAPI.registerPreload('video-button-response', 'sources', 'video');
 
   plugin.info = {
     name: 'video-button-response',

--- a/plugins/jspsych-video-button-response.js
+++ b/plugins/jspsych-video-button-response.js
@@ -272,7 +272,7 @@ jsPsych.plugins["video-button-response"] = (function() {
       // gather the data to store for the trial
       var trial_data = {
         "rt": response.rt,
-        "stimulus": trial.stimulus,
+        "sources": trial.sources,
         "button_pressed": response.button
       };
 

--- a/plugins/jspsych-video-button-response.js
+++ b/plugins/jspsych-video-button-response.js
@@ -12,13 +12,13 @@ jsPsych.plugins["video-button-response"] = (function() {
 
   var plugin = {};
 
-  jsPsych.pluginAPI.registerPreload('video-button-response', 'sources', 'video');
+  jsPsych.pluginAPI.registerPreload('video-button-response', 'stimulus', 'video');
 
   plugin.info = {
     name: 'video-button-response',
     description: '',
     parameters: {
-      sources: {
+      stimulus: {
         type: jsPsych.plugins.parameterType.VIDEO,
         pretty_name: 'Video',
         default: undefined,
@@ -153,10 +153,10 @@ jsPsych.plugins["video-button-response"] = (function() {
     }
     video_html +=">";
 
-    var video_preload_blob = jsPsych.pluginAPI.getVideoBuffer(trial.sources[0]);
+    var video_preload_blob = jsPsych.pluginAPI.getVideoBuffer(trial.stimulus[0]);
     if(!video_preload_blob) {
-      for(var i=0; i<trial.sources.length; i++){
-        var file_name = trial.sources[i];
+      for(var i=0; i<trial.stimulus.length; i++){
+        var file_name = trial.stimulus[i];
         if(file_name.indexOf('?') > -1){
           file_name = file_name.substring(0, file_name.indexOf('?'));
         }
@@ -272,7 +272,7 @@ jsPsych.plugins["video-button-response"] = (function() {
       // gather the data to store for the trial
       var trial_data = {
         "rt": response.rt,
-        "sources": trial.sources,
+        "stimulus": trial.stimulus,
         "button_pressed": response.button
       };
 

--- a/plugins/jspsych-video-keyboard-response.js
+++ b/plugins/jspsych-video-keyboard-response.js
@@ -12,13 +12,13 @@ jsPsych.plugins["video-keyboard-response"] = (function() {
 
   var plugin = {};
 
-  jsPsych.pluginAPI.registerPreload('video-keyboard-response', 'sources', 'video');
+  jsPsych.pluginAPI.registerPreload('video-keyboard-response', 'stimulus', 'video');
 
   plugin.info = {
     name: 'video-keyboard-response',
     description: '',
     parameters: {
-      sources: {
+      stimulus: {
         type: jsPsych.plugins.parameterType.VIDEO,
         pretty_name: 'Video',
         default: undefined,
@@ -134,10 +134,10 @@ jsPsych.plugins["video-keyboard-response"] = (function() {
     }
     video_html +=">";
 
-    var video_preload_blob = jsPsych.pluginAPI.getVideoBuffer(trial.sources[0]);
+    var video_preload_blob = jsPsych.pluginAPI.getVideoBuffer(trial.stimulus[0]);
     if(!video_preload_blob) {
-      for(var i=0; i<trial.sources.length; i++){
-        var file_name = trial.sources[i];
+      for(var i=0; i<trial.stimulus.length; i++){
+        var file_name = trial.stimulus[i];
         if(file_name.indexOf('?') > -1){
           file_name = file_name.substring(0, file_name.indexOf('?'));
         }
@@ -228,7 +228,7 @@ jsPsych.plugins["video-keyboard-response"] = (function() {
       // gather the data to store for the trial
       var trial_data = {
         "rt": response.rt,
-        "sources": trial.sources,
+        "stimulus": trial.stimulus,
         "key_press": response.key
       };
 

--- a/plugins/jspsych-video-keyboard-response.js
+++ b/plugins/jspsych-video-keyboard-response.js
@@ -228,7 +228,7 @@ jsPsych.plugins["video-keyboard-response"] = (function() {
       // gather the data to store for the trial
       var trial_data = {
         "rt": response.rt,
-        "stimulus": trial.stimulus,
+        "sources": trial.sources,
         "key_press": response.key
       };
 

--- a/plugins/jspsych-video-keyboard-response.js
+++ b/plugins/jspsych-video-keyboard-response.js
@@ -12,7 +12,7 @@ jsPsych.plugins["video-keyboard-response"] = (function() {
 
   var plugin = {};
 
-  jsPsych.pluginAPI.registerPreload('video-keyboard-response', 'stimulus', 'video');
+  jsPsych.pluginAPI.registerPreload('video-keyboard-response', 'sources', 'video');
 
   plugin.info = {
     name: 'video-keyboard-response',

--- a/plugins/jspsych-video-slider-response.js
+++ b/plugins/jspsych-video-slider-response.js
@@ -310,7 +310,7 @@ jsPsych.plugins["video-slider-response"] = (function() {
       // gather the data to store for the trial
       var trial_data = {
         "rt": response.rt,
-        "stimulus": trial.stimulus,
+        "sources": trial.sources,
         "start": trial.start,
         "slider_start": trial.slider_start,
         "response": response.response

--- a/plugins/jspsych-video-slider-response.js
+++ b/plugins/jspsych-video-slider-response.js
@@ -12,13 +12,13 @@ jsPsych.plugins["video-slider-response"] = (function() {
 
   var plugin = {};
 
-  jsPsych.pluginAPI.registerPreload('video-slider-response', 'sources', 'video');
+  jsPsych.pluginAPI.registerPreload('video-slider-response', 'stimulus', 'video');
 
   plugin.info = {
     name: 'video-slider-response',
     description: '',
     parameters: {
-      sources: {
+      stimulus: {
         type: jsPsych.plugins.parameterType.VIDEO,
         pretty_name: 'Video',
         default: undefined,
@@ -176,10 +176,10 @@ jsPsych.plugins["video-slider-response"] = (function() {
     }
     video_html +=">";
 
-    var video_preload_blob = jsPsych.pluginAPI.getVideoBuffer(trial.sources[0]);
+    var video_preload_blob = jsPsych.pluginAPI.getVideoBuffer(trial.stimulus[0]);
     if(!video_preload_blob) {
-      for(var i=0; i<trial.sources.length; i++){
-        var file_name = trial.sources[i];
+      for(var i=0; i<trial.stimulus.length; i++){
+        var file_name = trial.stimulus[i];
         if(file_name.indexOf('?') > -1){
           file_name = file_name.substring(0, file_name.indexOf('?'));
         }
@@ -310,7 +310,7 @@ jsPsych.plugins["video-slider-response"] = (function() {
       // gather the data to store for the trial
       var trial_data = {
         "rt": response.rt,
-        "sources": trial.sources,
+        "stimulus": trial.stimulus,
         "start": trial.start,
         "slider_start": trial.slider_start,
         "response": response.response

--- a/plugins/jspsych-video-slider-response.js
+++ b/plugins/jspsych-video-slider-response.js
@@ -12,7 +12,7 @@ jsPsych.plugins["video-slider-response"] = (function() {
 
   var plugin = {};
 
-  jsPsych.pluginAPI.registerPreload('video-slider-response', 'stimulus', 'video');
+  jsPsych.pluginAPI.registerPreload('video-slider-response', 'sources', 'video');
 
   plugin.info = {
     name: 'video-slider-response',


### PR DESCRIPTION
I noticed that video stimuli weren't automatically preloading at the start of experiments with video response plugin trials. 

Per the API documentation, plugin media are preloaded with a call to:
`jsPsych.pluginAPI.registerPreload(plugin_name, parameter, media_type, conditional_function)`

Looking at the video response plugins, the value for `parameter` ("The name of the parameter that is a media file.") was set to 'stimulus', which isn't one of the plugin parameters. 

I replaced 'stimulus' with 'sources' ("The video file to play.") and that fixed the issue.

This PR replaces 'stimulus' with 'sources' in: 
- `jspsych-video-keyboard-response.js`
- `jspsych-video-button-response.js`
- `jspsych-video-slider-response.js`



