### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fjspsych%2FjsPsych&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
+
 ![logo](http://www.jspsych.org/img/jspsych-logo.jpg)
 
 jsPsych is a JavaScript library for creating behavioral experiments that run in a web browser. jsPsych provides a framework for defining experiments using a set of flexible plugins that create different kinds of tasks a subject could complete during an experiment. By assembling these different plugins together it is possible to create many different types of experiments.


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

![Screenshot (1681)](https://user-images.githubusercontent.com/47092464/98456072-c69d6b00-21b3-11eb-9244-4164051621ce.png)
