### PR TITLE
[audio-button-response] Fix undefined startTime

### DIFF
--- a/plugins/jspsych-audio-button-response.js
+++ b/plugins/jspsych-audio-button-response.js
@@ -224,8 +224,7 @@ jsPsych.plugins["audio-button-response"] = (function() {
 
 		// start audio
     if(context !== null){
-      startTime = context.currentTime;
-      source.start(startTime);
+      source.start(context.currentTime);
     } else {
       audio.play();
     }


### PR DESCRIPTION
In the plugin `audio-button-response` when the audio is started and `context` is already defined a `startAudio` variable is used, but never defined, this causes e JS error: `Uncaught ReferenceError: startTime is not defined`.

This fixes the issue by inlining the variable since this was not reused anywhere else.