### PR TITLE
for using the free-sort plugin with a touch device.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Thumbs.db
 /.project
 /.tern-project
 site/
+examples/jspsych-free-sort-check.html

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ Thumbs.db
 /.project
 /.tern-project
 site/
-examples/jspsych-free-sort-check.html

--- a/examples/jspsych-free-sort.html
+++ b/examples/jspsych-free-sort.html
@@ -12,8 +12,10 @@
   var trial_1 = {
     type: 'free-sort',
     stimuli: ['img/happy_face_1.jpg','img/happy_face_3.jpg','img/sad_face_2.jpg','img/sad_face_4.jpg'],
-    stim_height: 150,
-    stim_width: 200,
+    stim_height: 120,
+    stim_width: 160,
+    sort_area_height: 500,
+    sort_area_width: 500,
     prompt: 'Please group similar expressions together. '
   };
 
@@ -24,8 +26,8 @@
     stim_width: 160,
     prompt: '<p>Arrange the faces.</p>',
     prompt_location: "below",
-    sort_area_height: 500,
-    sort_area_width: 600,
+    sort_area_height: 400,
+    sort_area_width: 500,
     sort_area_shape: "square",
     scale_factor: 1.2,
     border_color_in: '#DCDCDC',
@@ -54,7 +56,7 @@
         ctx.drawImage(img3, 300, 100,  90, 90);
       }, false);
     },
-    canvas_size: [700,700],
+    canvas_size: [500,500],
     prompt: "Memorize the image locations (5s).",
     choices: jsPsych.NO_KEYS,
     trial_duration: 5000
@@ -69,6 +71,8 @@
     prompt: '<p>Where were the images?</p>',
     prompt_location: 'below',
     sort_area_shape: "square",
+    sort_area_height: 500,
+    sort_area_width: 500,
     change_border_background_color: false,
     border_width: 5,
     counter_text_unfinished: "Not done yet...",


### PR DESCRIPTION
I noticed that [the free-sort plugin is about to be improved.](https://github.com/jspsych/jsPsych/pull/1203)
In fact, I was also changing the plugin to use with a touch device.
Could you merge my pull request in addition to yours?

Note that when running the new example programs, the both the sort_area_height and sort_area_width properties need to be set to around 400 so that the images can be presented properly with a touch device.
