### PR TITLE
video-* plugins: stim parameter name change and tests

### DIFF
--- a/docs/plugins/jspsych-video-button-response.md
+++ b/docs/plugins/jspsych-video-button-response.md
@@ -8,7 +8,7 @@ Parameters with a default value of *undefined* must be specified. Other paramete
 
 Parameter | Type | Default Value | Description
 ----------|------|---------------|------------
-sources | array | *undefined* | An array of file paths to the video. You can specify multiple formats of the same video (e.g., .mp4, .ogg, .webm) to maximize the [cross-browser compatibility](https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats). Usually .mp4 is a safe cross-browser option. The plugin does not reliably support .mov files. The player will use the first source file in the array that is compatible with the browser, so specify the files in order of preference.
+stimulus | array | *undefined* | An array of file paths to the video. You can specify multiple formats of the same video (e.g., .mp4, .ogg, .webm) to maximize the [cross-browser compatibility](https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats). Usually .mp4 is a safe cross-browser option. The plugin does not reliably support .mov files. The player will use the first source file in the array that is compatible with the browser, so specify the files in order of preference.
 choices | array of strings | [] | Labels for the buttons. Each different string in the array will generate a different button.
 button_html | HTML string | `'<button class="jspsych-btn">%choice%</button>'` | A template of HTML for generating the button elements. You can override this to create customized buttons of various kinds. The string `%choice%` will be changed to the corresponding element of the `choices` array. You may also specify an array of strings, if you need different HTML to render for each button. If you do specify an array, the `choices` array and this array must have the same length. The HTML from position 0 in the `button_html` array will be used to create the button for element 0 in the `choices` array, and so on.
 margin_vertical | string | '0px' | Vertical margin of the button(s).
@@ -35,14 +35,14 @@ Name | Type | Value
 -----|------|------
 button_pressed | numeric | Indicates which button the subject pressed. The first button in the `choices` array is 0, the second is 1, and so on.
 rt | numeric | The response time in milliseconds for the subject to make a response. The time is measured from when the stimulus first appears on the screen until the subject's response.
-stimulus | string | JSON encoding of the `sources` array.
+stimulus | string | JSON encoding of the `stimulus` array.
 
 ## Example
 
 ```javascript
 var trial = {
 	type: 'video-button-response',
-	sources: [
+	stimulus: [
 		'video/sample_video.mp4',
 		'video/sample_video.ogg'
 	],

--- a/docs/plugins/jspsych-video-keyboard-response.md
+++ b/docs/plugins/jspsych-video-keyboard-response.md
@@ -8,7 +8,7 @@ Parameters with a default value of *undefined* must be specified. Other paramete
 
 Parameter | Type | Default Value | Description
 ----------|------|---------------|------------
-sources | array | *undefined* | An array of file paths to the video. You can specify multiple formats of the same video (e.g., .mp4, .ogg, .webm) to maximize the [cross-browser compatibility](https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats). Usually .mp4 is a safe cross-browser option. The plugin does not reliably support .mov files. The player will use the first source file in the array that is compatible with the browser, so specify the files in order of preference.
+stimulus | array | *undefined* | An array of file paths to the video. You can specify multiple formats of the same video (e.g., .mp4, .ogg, .webm) to maximize the [cross-browser compatibility](https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats). Usually .mp4 is a safe cross-browser option. The plugin does not reliably support .mov files. The player will use the first source file in the array that is compatible with the browser, so specify the files in order of preference.
 prompt | string | null | This string can contain HTML markup. Any content here will be displayed below the stimulus. The intention is that it can be used to provide a reminder about the action the subject is supposed to take (e.g., which key to press).
 width | numeric | width of the video file | The width of the video display in pixels.
 height | numeric | heigh of the video file | The height of the video display in pixels.
@@ -31,14 +31,14 @@ Name | Type | Value
 -----|------|------
 key_press | numeric | Indicates which key the subject pressed. The value is the [numeric key code](http://www.cambiaresearch.com/articles/15/javascript-char-codes-key-codes) corresponding to the subject's response.
 rt | numeric | The response time in milliseconds for the subject to make a response. The time is measured from when the stimulus first appears on the screen until the subject's response.
-stimulus | string | JSON encoding of the `sources` array.
+stimulus | string | JSON encoding of the `stimulus` array.
 
 ## Example
 
 ```javascript
 var trial = {
 	type: 'video-keyboard-response',
-	sources: [
+	stimulus: [
 		'video/sample_video.mp4',
 		'video/sample_video.ogg'
 	],

--- a/docs/plugins/jspsych-video-slider-response.md
+++ b/docs/plugins/jspsych-video-slider-response.md
@@ -8,7 +8,7 @@ Parameters with a default value of *undefined* must be specified. Other paramete
 
 Parameter | Type | Default Value | Description
 ----------|------|---------------|------------
-sources | array | *undefined* | An array of file paths to the video. You can specify multiple formats of the same video (e.g., .mp4, .ogg, .webm) to maximize the [cross-browser compatibility](https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats). Usually .mp4 is a safe cross-browser option. The plugin does not reliably support .mov files. The player will use the first source file in the array that is compatible with the browser, so specify the files in order of preference.
+stimulus | array | *undefined* | An array of file paths to the video. You can specify multiple formats of the same video (e.g., .mp4, .ogg, .webm) to maximize the [cross-browser compatibility](https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats). Usually .mp4 is a safe cross-browser option. The plugin does not reliably support .mov files. The player will use the first source file in the array that is compatible with the browser, so specify the files in order of preference.
 prompt | string | null | This string can contain HTML markup. Any content here will be displayed below the stimulus. The intention is that it can be used to provide a reminder about the action the subject is supposed to take (e.g., which key to press).
 width | numeric | width of the video file | The width of the video display in pixels.
 height | numeric | heigh of the video file | The height of the video display in pixels.
@@ -38,7 +38,7 @@ Name | Type | Value
 -----|------|------
 response | numeric | The numeric value of the slider.
 rt | numeric | The response time in milliseconds for the subject to make a response. The time is measured from when the stimulus first appears on the screen until the subject's response.
-stimulus | string | JSON encoding of the `sources` array.
+stimulus | string | JSON encoding of the `stimulus` array.
 slider_start | numeric | The starting value of the slider.
 start | numeric | The start time of the video clip.
 
@@ -47,7 +47,7 @@ start | numeric | The start time of the video clip.
 ```javascript
 var trial = {
 	type: 'video-slider-response',
-	sources: [
+	stimulus: [
 		'video/sample_video.mp4',
 		'video/sample_video.ogg'
 	],

--- a/examples/jspsych-video-button-response.html
+++ b/examples/jspsych-video-button-response.html
@@ -17,7 +17,7 @@
 
   var trial_1 = {
     type: 'video-button-response',
-    sources: ['video/sample_video.mp4'],
+    stimulus: ['video/sample_video.mp4'],
     choices: ['y','n'],
     button_html: '<button class="jspsych-btn">%choice%!</button>',
     margin_vertical: '10px',
@@ -36,7 +36,7 @@
 
     var trial_2 = {
     type: 'video-button-response',
-    sources: ['video/sample_video.mp4'],
+    stimulus: ['video/sample_video.mp4'],
     choices: ['Great','Not great'],
     margin_vertical: '10px',
     margin_horizontal: '8px',
@@ -48,7 +48,6 @@
   }
 
   jsPsych.init({
-
     show_preload_progress_bar: true,
     timeline: [pre_trial, trial_1, trial_2],
     on_finish: function() { jsPsych.data.displayData(); }

--- a/examples/jspsych-video-keyboard-response.html
+++ b/examples/jspsych-video-keyboard-response.html
@@ -17,7 +17,7 @@
 
   var trial_1 = {
     type: 'video-keyboard-response',
-    sources: ['video/sample_video.mp4'],
+    stimulus: ['video/sample_video.mp4'],
     choices: ['y','n'],
     prompt: 'Press Y or N',
     width: 600,
@@ -34,7 +34,7 @@
 
   var trial_2 = {
     type: 'video-keyboard-response',
-    sources: ['video/sample_video.mp4'],
+    stimulus: ['video/sample_video.mp4'],
     choices: jsPsych.ALL_KEYS,
     prompt: '<p>When the video stops, press any key to end the trial.</p><p>Responses that are made before the video ends will be ignored.</p>',
     width: 600,

--- a/examples/jspsych-video-slider-response.html
+++ b/examples/jspsych-video-slider-response.html
@@ -17,7 +17,7 @@
 
   var trial_1 = {
     type: 'video-slider-response',
-    sources: ['video/sample_video.mp4'],
+    stimulus: ['video/sample_video.mp4'],
     labels: ['1 Star', '2 Stars', '3 Stars', '4 Stars', '5 Stars'],
     min: 1,
     max: 5,
@@ -33,7 +33,7 @@
 
   var trial_2 = {
     type: 'video-slider-response',
-    sources: ['video/sample_video.mp4'],
+    stimulus: ['video/sample_video.mp4'],
     labels: ['1 Star', '2 Stars', '3 Stars', '4 Stars', '5 Stars'],
     min: 1,
     max: 5,
@@ -46,7 +46,6 @@
   }
 
   jsPsych.init({
-
     show_preload_progress_bar: true,
     timeline: [pre_trial, trial_1, trial_2],
     on_finish: function() { jsPsych.data.displayData(); }

--- a/jspsych.js
+++ b/jspsych.js
@@ -2578,15 +2578,15 @@ jsPsych.pluginAPI = (function() {
       var trials = timeline.trialsOfType(type);
       for (var j = 0; j < trials.length; j++) {
 
-        if (trials[j][param] && typeof trials[j][param] !== 'function') {
-
+        if (typeof trials[j][param] == 'undefined') {
+          console.warn("jsPsych failed to auto preload one or more files: no parameter called "+param+" in plugin "+type);
+        } else if (typeof trials[j][param] !== 'function') {
           if ( !func  || func(trials[j]) ){
             if (media === 'image') {
               images = images.concat(jsPsych.utils.flatten([trials[j][param]]));
             } else if (media === 'audio') {
               audio = audio.concat(jsPsych.utils.flatten([trials[j][param]]));
-            }
-            else if (media === 'video') {
+            } else if (media === 'video') {
               video = video.concat(jsPsych.utils.flatten([trials[j][param]]));
             }
           }

--- a/plugins/jspsych-video-button-response.js
+++ b/plugins/jspsych-video-button-response.js
@@ -18,7 +18,7 @@ jsPsych.plugins["video-button-response"] = (function() {
     name: 'video-button-response',
     description: '',
     parameters: {
-      sources: {
+      stimulus: {
         type: jsPsych.plugins.parameterType.VIDEO,
         pretty_name: 'Video',
         default: undefined,
@@ -153,10 +153,10 @@ jsPsych.plugins["video-button-response"] = (function() {
     }
     video_html +=">";
 
-    var video_preload_blob = jsPsych.pluginAPI.getVideoBuffer(trial.sources[0]);
+    var video_preload_blob = jsPsych.pluginAPI.getVideoBuffer(trial.stimulus[0]);
     if(!video_preload_blob) {
-      for(var i=0; i<trial.sources.length; i++){
-        var file_name = trial.sources[i];
+      for(var i=0; i<trial.stimulus.length; i++){
+        var file_name = trial.stimulus[i];
         if(file_name.indexOf('?') > -1){
           file_name = file_name.substring(0, file_name.indexOf('?'));
         }

--- a/plugins/jspsych-video-keyboard-response.js
+++ b/plugins/jspsych-video-keyboard-response.js
@@ -18,7 +18,7 @@ jsPsych.plugins["video-keyboard-response"] = (function() {
     name: 'video-keyboard-response',
     description: '',
     parameters: {
-      sources: {
+      stimulus: {
         type: jsPsych.plugins.parameterType.VIDEO,
         pretty_name: 'Video',
         default: undefined,
@@ -134,10 +134,10 @@ jsPsych.plugins["video-keyboard-response"] = (function() {
     }
     video_html +=">";
 
-    var video_preload_blob = jsPsych.pluginAPI.getVideoBuffer(trial.sources[0]);
+    var video_preload_blob = jsPsych.pluginAPI.getVideoBuffer(trial.stimulus[0]);
     if(!video_preload_blob) {
-      for(var i=0; i<trial.sources.length; i++){
-        var file_name = trial.sources[i];
+      for(var i=0; i<trial.stimulus.length; i++){
+        var file_name = trial.stimulus[i];
         if(file_name.indexOf('?') > -1){
           file_name = file_name.substring(0, file_name.indexOf('?'));
         }

--- a/plugins/jspsych-video-slider-response.js
+++ b/plugins/jspsych-video-slider-response.js
@@ -18,7 +18,7 @@ jsPsych.plugins["video-slider-response"] = (function() {
     name: 'video-slider-response',
     description: '',
     parameters: {
-      sources: {
+      stimulus: {
         type: jsPsych.plugins.parameterType.VIDEO,
         pretty_name: 'Video',
         default: undefined,
@@ -179,10 +179,10 @@ jsPsych.plugins["video-slider-response"] = (function() {
     }
     video_html +=">";
 
-    var video_preload_blob = jsPsych.pluginAPI.getVideoBuffer(trial.sources[0]);
+    var video_preload_blob = jsPsych.pluginAPI.getVideoBuffer(trial.stimulus[0]);
     if(!video_preload_blob) {
-      for(var i=0; i<trial.sources.length; i++){
-        var file_name = trial.sources[i];
+      for(var i=0; i<trial.stimulus.length; i++){
+        var file_name = trial.stimulus[i];
         if(file_name.indexOf('?') > -1){
           file_name = file_name.substring(0, file_name.indexOf('?'));
         }

--- a/tests/plugins/plugin-video-button-response.test.js
+++ b/tests/plugins/plugin-video-button-response.test.js
@@ -6,16 +6,18 @@ describe('video-button-response plugin', function(){
 
 	beforeEach(function(){
 		require(root + 'jspsych.js');
-		require(root + 'plugins/jspsych-video-button-response.js');
+		// don't load plugin here - need to spy on registerPreload before its called
 	});
 
 	test('loads correctly', function(){
+		require(root + 'plugins/jspsych-video-button-response.js');
 		expect(typeof window.jsPsych.plugins['video-button-response']).not.toBe('undefined');
 	});
 
 	test('video preloading initiates automatically', function(){
 		const preload_spy = jest.spyOn(jsPsych.pluginAPI, 'registerPreload');
 		const console_spy = jest.spyOn(console, 'warn');
+		require(root + 'plugins/jspsych-video-button-response.js');
 		var trial = {
 			type: 'video-button-response',
 			stimulus: [root + 'tests/media/sample_video.mp4'],
@@ -24,7 +26,7 @@ describe('video-button-response plugin', function(){
 		jsPsych.init({
 			timeline: [trial]
 		});
-		//expect(preload_spy).toHaveBeenCalled(); // NOT WORKING
+		expect(preload_spy).toHaveBeenCalled(); 
 		expect(console_spy).not.toHaveBeenCalled();
 		preload_spy.mockRestore();
 		console_spy.mockRestore();

--- a/tests/plugins/plugin-video-button-response.test.js
+++ b/tests/plugins/plugin-video-button-response.test.js
@@ -13,4 +13,21 @@ describe('video-button-response plugin', function(){
 		expect(typeof window.jsPsych.plugins['video-button-response']).not.toBe('undefined');
 	});
 
+	test('video preloading initiates automatically', function(){
+		const preload_spy = jest.spyOn(jsPsych.pluginAPI, 'registerPreload');
+		const console_spy = jest.spyOn(console, 'warn');
+		var trial = {
+			type: 'video-button-response',
+			stimulus: [root + 'tests/media/sample_video.mp4'],
+			choices: ['y']
+		}
+		jsPsych.init({
+			timeline: [trial]
+		});
+		//expect(preload_spy).toHaveBeenCalled(); // NOT WORKING
+		expect(console_spy).not.toHaveBeenCalled();
+		preload_spy.mockRestore();
+		console_spy.mockRestore();
+	});
+
 });

--- a/tests/plugins/plugin-video-keyboard-response.test.js
+++ b/tests/plugins/plugin-video-keyboard-response.test.js
@@ -6,16 +6,18 @@ describe('video-keyboard-response plugin', function(){
 
 	beforeEach(function(){
 		require(root + 'jspsych.js');
-		require(root + 'plugins/jspsych-video-keyboard-response.js');
+		// don't load plugin here - need to spy on registerPreload before its called
 	});
 
 	test('loads correctly', function(){
+		require(root + 'plugins/jspsych-video-keyboard-response.js');
 		expect(typeof window.jsPsych.plugins['video-keyboard-response']).not.toBe('undefined');
 	});
 
 	test('video preloading initiates automatically', function(){
 		const preload_spy = jest.spyOn(jsPsych.pluginAPI, 'registerPreload');
 		const console_spy = jest.spyOn(console, 'warn');
+		require(root + 'plugins/jspsych-video-keyboard-response.js');
 		var trial = {
 			type: 'video-keyboard-response',
 			stimulus: [root + 'tests/media/sample_video.mp4'],
@@ -24,7 +26,7 @@ describe('video-keyboard-response plugin', function(){
 		jsPsych.init({
 			timeline: [trial]
 		});
-		//expect(preload_spy).toHaveBeenCalled(); // NOT WORKING
+		expect(preload_spy).toHaveBeenCalled(); 
 		expect(console_spy).not.toHaveBeenCalled();
 		preload_spy.mockRestore();
 		console_spy.mockRestore();

--- a/tests/plugins/plugin-video-keyboard-response.test.js
+++ b/tests/plugins/plugin-video-keyboard-response.test.js
@@ -13,4 +13,21 @@ describe('video-keyboard-response plugin', function(){
 		expect(typeof window.jsPsych.plugins['video-keyboard-response']).not.toBe('undefined');
 	});
 
+	test('video preloading initiates automatically', function(){
+		const preload_spy = jest.spyOn(jsPsych.pluginAPI, 'registerPreload');
+		const console_spy = jest.spyOn(console, 'warn');
+		var trial = {
+			type: 'video-keyboard-response',
+			stimulus: [root + 'tests/media/sample_video.mp4'],
+			choices: jsPsych.ALL_KEYS
+		}
+		jsPsych.init({
+			timeline: [trial]
+		});
+		//expect(preload_spy).toHaveBeenCalled(); // NOT WORKING
+		expect(console_spy).not.toHaveBeenCalled();
+		preload_spy.mockRestore();
+		console_spy.mockRestore();
+	});
+
 });

--- a/tests/plugins/plugin-video-slider-response.test.js
+++ b/tests/plugins/plugin-video-slider-response.test.js
@@ -6,16 +6,18 @@ describe('video-slider-response plugin', function(){
 
 	beforeEach(function(){
 		require(root + 'jspsych.js');
-		require(root + 'plugins/jspsych-video-slider-response.js');
+		// don't load plugin here - need to spy on registerPreload before its called
 	});
 
 	test('loads correctly', function(){
+		require(root + 'plugins/jspsych-video-slider-response.js');
 		expect(typeof window.jsPsych.plugins['video-slider-response']).not.toBe('undefined');
 	});
 
 	test('video preloading initiates automatically', function(){
 		const preload_spy = jest.spyOn(jsPsych.pluginAPI, 'registerPreload');
 		const console_spy = jest.spyOn(console, 'warn');
+		require(root + 'plugins/jspsych-video-slider-response.js');
 		var trial = {
 			type: 'video-slider-response',
 			stimulus: [root + 'tests/media/sample_video.mp4']
@@ -23,7 +25,7 @@ describe('video-slider-response plugin', function(){
 		jsPsych.init({
 			timeline: [trial]
 		});
-		//expect(preload_spy).toHaveBeenCalled(); // NOT WORKING
+		expect(preload_spy).toHaveBeenCalled();
 		expect(console_spy).not.toHaveBeenCalled();
 		preload_spy.mockRestore();
 		console_spy.mockRestore();

--- a/tests/plugins/plugin-video-slider-response.test.js
+++ b/tests/plugins/plugin-video-slider-response.test.js
@@ -13,4 +13,20 @@ describe('video-slider-response plugin', function(){
 		expect(typeof window.jsPsych.plugins['video-slider-response']).not.toBe('undefined');
 	});
 
+	test('video preloading initiates automatically', function(){
+		const preload_spy = jest.spyOn(jsPsych.pluginAPI, 'registerPreload');
+		const console_spy = jest.spyOn(console, 'warn');
+		var trial = {
+			type: 'video-slider-response',
+			stimulus: [root + 'tests/media/sample_video.mp4']
+		}
+		jsPsych.init({
+			timeline: [trial]
+		});
+		//expect(preload_spy).toHaveBeenCalled(); // NOT WORKING
+		expect(console_spy).not.toHaveBeenCalled();
+		preload_spy.mockRestore();
+		console_spy.mockRestore();
+	});
+
 });


### PR DESCRIPTION
These are the changes from @mgorenstein's pull request (#1171), merged into this branch so that I could also update the documentation and example HTML files with the new parameter name.

I also added tests to each of the plugin test files to make sure that (1) the plugin files are calling the `registerPreload` function, and (2) the parameter name that is used in that function exists in the plugin (to catch the `stimulus`/`sources` name error that was preventing video preloading before). 

1. The easiest way I could think of to test whether an incorrect parameter name was used in `jsPsych.pluginAPI.registerPreload` was to modify jspsych.js so that it produces a console warning if the parameter in the `preloads` list is undefined, and then detect this console warning in the test. This test is working, i.e. it fails when `jsPsych.pluginAPI.registerPreload` uses a parameter name that doesn't exist in the trial object and passes when `stimulus` is used as the parameter name.

2. I couldn't get the `jest.spyOn()` function to work for spying on `jsPsych.pluginAPI.registerPreload`. I thought that this would work:`
const preload_spy = jest.spyOn(jsPsych.pluginAPI, 'registerPreload');
//... set up and run video trial
expect(preload_spy).toHaveBeenCalled();
` But this always fails, saying that `preload_spy` was not called. I kept this in the code but commented out the `expect` line to make the tests pass. @jodeleeuw any ideas/suggetions?

Also @jodeleeuw I realize that this sort of testing isn't quite what you meant in [this comment](https://github.com/jspsych/jsPsych/pull/1171#issuecomment-722563394), but figured this was the quickest way to see if I can get the preload tests working. I can test this in a different way and move the tests somewhere else if you prefer. I think including preload tests somewhere will be useful for #1258.