### PR TITLE
Check fullscreen is active before exiting fullscreen

### DIFF
--- a/plugins/jspsych-fullscreen.js
+++ b/plugins/jspsych-fullscreen.js
@@ -69,14 +69,16 @@ jsPsych.plugins.fullscreen = (function() {
           endTrial();
         });
       } else {
-        if (document.exitFullscreen) {
-          document.exitFullscreen();
-        } else if (document.msExitFullscreen) {
-          document.msExitFullscreen();
-        } else if (document.mozCancelFullScreen) {
-          document.mozCancelFullScreen();
-        } else if (document.webkitExitFullscreen) {
-          document.webkitExitFullscreen();
+        if ( document.fullscreenElement || document.mozFullScreenElement || document.webkitFullscreenElement ) {
+          if (document.exitFullscreen) {
+            document.exitFullscreen();
+          } else if (document.msExitFullscreen) {
+            document.msExitFullscreen();
+          } else if (document.mozCancelFullScreen) {
+            document.mozCancelFullScreen();
+          } else if (document.webkitExitFullscreen) {
+            document.webkitExitFullscreen();
+          }
         }
         endTrial();
       }


### PR DESCRIPTION
I was getting a `Document not active` error and this fixes it. The change checks that the document is in fullscreen mode and only calls the exit functions if it is in fullscreen.

I am exiting my experiment through a callback, using the 'call-function' plugin. That trial is pushed to the timeline following the fullscreen off trial. I would have figured that would be okay but it kept throwing the error at the end of the experiment.