### PR TITLE
Fixed typo in media-preloading.md

### DIFF
--- a/docs/overview/media-preloading.md
+++ b/docs/overview/media-preloading.md
@@ -52,7 +52,7 @@ var audio_trial = {
 	stimulus: function() { return 'audio/foo.mp3' }
 }
 
-var video_timline = {
+var video_timeline = {
 	timeline: [
 		{
 			type: 'video',


### PR DESCRIPTION
Hello, 

I've just fixed a typo (`timline`) in media-preloading.md

Best regards