### PR TITLE
Add method to select a set of columns from data object (inverse of `.ignore()`)

### DIFF
--- a/docs/core_library/jspsych-data.md
+++ b/docs/core_library/jspsych-data.md
@@ -465,6 +465,13 @@ Returns a DataColumn object (see documentation below) of a single property from 
 var rt_data = jsPsych.data.get().select('rt');
 rt_data.mean()
 ```
+#### .filterColumns()
+
+Filter the saved columns and arrange them in order，it will return a DataCollection object.
+
+```js
+console.log(jsPsych.data.get().filterColumns(jsPsych.data.get().uniqueNames().sort()))
+```
 
 #### .uniqueNames()
 

--- a/jspsych.js
+++ b/jspsych.js
@@ -1483,6 +1483,24 @@ jsPsych.data = (function() {
       return out;
     }
 
+    data_collection.filterColumns = function(columns){ 
+      let keys = typeof columns !== "undefined" ? columns : [];
+      if (keys.length < 1) {
+        return DataCollection(trials);
+      } else { 
+        var new_trials = [];
+        for(var i in trials) { 
+          var new_trial = {};
+          keys.forEach(function(key){
+            new_trial[key] = trials[i][key];
+          })
+          new_trials.push(new_trial);
+        }
+        return DataCollection(new_trials);
+      }
+
+    }
+
     data_collection.ignore = function(columns){
       if(!Array.isArray(columns)){
         columns = [columns];


### PR DESCRIPTION
I added an array variable `keys` in JSON2CSV
In this way, I can filter the columns that I need to save and save them in order, which can reduce the workload of processing the data
for instance：
```
jsPsych.data.get().csv()
# "\"success\",\"hhhh\",\"trial_type\",\"trial_index\",\"time_elapsed\",\"internal_node_id\"
# \"true\",\"123\",\"fullscreen\",\"0\",\"1881\",\"0.0-0.0\"
```

```
jsPsych.data.get().csv(["hhhh", "success"])
# "\"hhhh\",\"success\"
# \"123\",\"true\"
```
It's easier to present，and i think it can work better with the code `jsPsych.data.get().uniqueNames()`