### PR TITLE
Add the scale_height property

### DIFF
--- a/docs/plugins/jspsych-survey-likert.md
+++ b/docs/plugins/jspsych-survey-likert.md
@@ -12,7 +12,7 @@ questions | array | *undefined* | An array of objects, each object represents a 
 randomize_question_order | boolean | `false` | If true, the display order of `questions` is randomly determined at the start of the trial. In the data object, `Q0` will still refer to the first question in the array, regardless of where it was presented visually.
 preamble | string | empty string | HTML formatted string to display at the top of the page above all the questions.
 scale_width | numeric | null | The width of the likert scale in pixels. If left `null`, then the width of the scale will be equal to the width of the widest content on the page.
-scale_height | numeric | null | The height of the likert scale in pixels. If it is specified, then A vertical scroll bar will appear.
+scale_height | numeric | null | The height of the likert scale in pixels. If it is specified, then a vertical scroll bar will appear.
 button_label | string |  'Continue' | Label of the button.
 autocomplete | boolean | false | This determines whether or not all of the input elements on the page should allow autocomplete. Setting this to true will enable autocomplete or auto-fill for the form.
 

--- a/docs/plugins/jspsych-survey-likert.md
+++ b/docs/plugins/jspsych-survey-likert.md
@@ -12,6 +12,7 @@ questions | array | *undefined* | An array of objects, each object represents a 
 randomize_question_order | boolean | `false` | If true, the display order of `questions` is randomly determined at the start of the trial. In the data object, `Q0` will still refer to the first question in the array, regardless of where it was presented visually.
 preamble | string | empty string | HTML formatted string to display at the top of the page above all the questions.
 scale_width | numeric | null | The width of the likert scale in pixels. If left `null`, then the width of the scale will be equal to the width of the widest content on the page.
+scale_height | numeric | null | The height of the likert scale in pixels. If it is specified, then A vertical scroll bar will appear.
 button_label | string |  'Continue' | Label of the button.
 autocomplete | boolean | false | This determines whether or not all of the input elements on the page should allow autocomplete. Setting this to true will enable autocomplete or auto-fill for the form.
 

--- a/examples/jspsych-survey-likert.html
+++ b/examples/jspsych-survey-likert.html
@@ -32,8 +32,22 @@
       scale_width: 500
   };
 
+  var likert_image_many_questions = {
+      type: 'survey-likert',
+      preamble: `<img src="img/happy_face_1.jpg">`,
+      questions: [
+        {prompt: "Question 1", labels: scale}, 
+        {prompt: "Question 2", labels: scale},
+        {prompt: "Question 3", labels: scale},
+        {prompt: "Question 4", labels: scale},
+        {prompt: "Question 5", labels: scale}
+      ],
+      scale_width: 500,
+      scale_height: 250,
+  };
+
   jsPsych.init({
-    timeline: [likert_trial, likert_trial_random_order],
+    timeline: [likert_trial, likert_trial_random_order, likert_image_many_questions],
     on_finish: function() { jsPsych.data.displayData(); }
   });
 

--- a/plugins/jspsych-survey-likert.js
+++ b/plugins/jspsych-survey-likert.js
@@ -66,6 +66,13 @@ jsPsych.plugins['survey-likert'] = (function() {
         default: null,
         description: 'Width of the likert scales in pixels.'
       },
+      scale_height: {
+        type: jsPsych.plugins.parameterType.INT,
+        pretty_name: 'Scale height',
+        default: null,
+        description: 'Height of the likert scales in pixels.'
+      },
+
       button_label: {
         type: jsPsych.plugins.parameterType.STRING,
         pretty_name: 'Button label',
@@ -104,6 +111,10 @@ jsPsych.plugins['survey-likert'] = (function() {
     // show preamble text
     if(trial.preamble !== null){
       html += '<div id="jspsych-survey-likert-preamble" class="jspsych-survey-likert-preamble">'+trial.preamble+'</div>';
+    }
+
+    if (trial.scale_height !== null) {
+      html += `<div style="width: 100%; height: ${trial.scale_height}px; overflow-y: scroll">`;
     }
 
     if ( trial.autocomplete ) {
@@ -145,6 +156,11 @@ jsPsych.plugins['survey-likert'] = (function() {
     html += '<input type="submit" id="jspsych-survey-likert-next" class="jspsych-survey-likert jspsych-btn" value="'+trial.button_label+'"></input>';
 
     html += '</form>'
+
+    if (trial.scale_height !== null) {
+      html += `</div">`;
+    }
+
 
     display_element.innerHTML = html;
 


### PR DESCRIPTION
In our lab, we had presented images using the jspsych-survey-likert plugin. Almost fine, but in this program, we had a problem where the image became invisible when there were a large number of questions.

So I added the scale_height property so that the participant can scroll only the area of questions while keeping the image fixed.

Best regards,