### PR TITLE
add show_value parameter to html-slider-response plugin

### DIFF
--- a/docs/plugins/jspsych-html-slider-response.md
+++ b/docs/plugins/jspsych-html-slider-response.md
@@ -17,6 +17,7 @@ slider_start | integer | 50 | Sets the starting value of the slider
 step | integer | 1 | Sets the step of the slider. This is the smallest amount by which the slider can change.
 slider_width | integer | null | Set the width of the slider in pixels. If left null, then the width will be equal to the widest element in the display.
 require_movement | boolean | false | If true, the subject must move the slider before clicking the continue button.
+show_value | boolean | false | If true, value of current position on slider will be shown below the slider.
 prompt | string | null | This string can contain HTML markup. Any content here will be displayed below the stimulus. The intention is that it can be used to provide a reminder about the action the subject is supposed to take (e.g., which key to press).
 stimulus_duration | numeric | null | How long to display the stimulus in milliseconds. The visibility CSS property of the stimulus will be set to `hidden` after this time has elapsed. If this is null, then the stimulus will remain visible until the trial ends.
 trial_duration | numeric | null | How long to wait for the subject to make a response before ending the trial in milliseconds. If the subject fails to make a response before this timer is reached, the subject's response will be recorded as null for the trial and the trial will end. If the value of this parameter is null, then the trial will wait for a response indefinitely.

--- a/examples/jspsych-html-slider-response.html
+++ b/examples/jspsych-html-slider-response.html
@@ -19,6 +19,7 @@
     labels: ['Purple', 'Blue'],
     slider_width: 500,
     require_movement: true,
+    show_value: true,
     prompt: '<p>Is this color closer to purple or blue? Use the slider above.</p>'
   }
 

--- a/plugins/jspsych-html-slider-response.js
+++ b/plugins/jspsych-html-slider-response.js
@@ -73,6 +73,12 @@ jsPsych.plugins['html-slider-response'] = (function() {
         default: false,
         description: 'If true, the participant will have to move the slider before continuing.'
       },
+      show_value: {
+        type: jsPsych.plugins.parameterType.BOOL,
+        pretty_name: "Show value",
+        default: false,
+        description: "If true, value of current position on slider will be shown below the slider."
+      },
       prompt: {
         type: jsPsych.plugins.parameterType.STRING,
         pretty_name: 'Prompt',
@@ -114,7 +120,11 @@ jsPsych.plugins['html-slider-response'] = (function() {
       html += 'width:auto;';
     }
     html += '">';
-    html += '<input type="range" class="jspsych-slider" value="'+trial.slider_start+'" min="'+trial.min+'" max="'+trial.max+'" step="'+trial.step+'" id="jspsych-html-slider-response-response"></input>';
+    if (trial.show_value) {
+      html += '<input type="range" class="jspsych-slider" value="' + trial.slider_start + '" min="' + trial.min + '" max="' + trial.max + '" step="' + trial.step + '" id="jspsych-html-slider-response-response" oninput="this.nextElementSibling.value = this.value"></input><output>' + trial.slider_start + '</output>';
+    } else {
+      html += '<input type="range" class="jspsych-slider" value="' + trial.slider_start + '" min="' + trial.min + '" max="' + trial.max + '" step="' + trial.step + '" id="jspsych-html-slider-response-response"></input><output></output>';
+    }
     html += '<div>'
     for(var j=0; j < trial.labels.length; j++){
       var label_width_perc = 100/(trial.labels.length-1);


### PR DESCRIPTION
Sometimes it's useful for participants to see the value of the current slider position (`html-slider-response`). I've added a `show_value` parameter to the slider plugin, as well as updated the documentation and example.