### PR TITLE
Fixed jspsych-webgazer-validate plugin documentation title

### DIFF
--- a/docs/plugins/jspsych-webgazer-validate.md
+++ b/docs/plugins/jspsych-webgazer-validate.md
@@ -1,4 +1,4 @@
-# jspsych-webgazer-calibrate
+# jspsych-webgazer-validate
 
 This plugin can be used to measure the accuracy and precision of gaze predictions made by the [WebGazer extension](/extensions/jspsych-ext-webgazer). For a narrative description of eye tracking with jsPsych, see the [eye tracking overview](/overview/eye-tracking). 
 


### PR DESCRIPTION
Fixes the title of the documentation page for the jspsych-webgazer-validate plugin (was "jspsych-webgazer-calibrate").