### PR TITLE
Update parameter name in experiment-options.md

### DIFF
--- a/docs/overview/experiment-options.md
+++ b/docs/overview/experiment-options.md
@@ -108,7 +108,7 @@ jsPsych.init({
 
 JavaScript keyboard events make a distinction between uppercase and lowercase key responses (e.g. 'a' and 'A'). Often the researcher just cares about which physical key was pressed, and not whether the key press would result in an uppercase letter (for instance, if CapsLock is on or if the Shift key is held down). For this reason, jsPsych converts all key choice parameters and key responses as lowercase by default. This makes it easier to specify key choices (e.g. `choices: ['a']`, instead of `choices: ['a','A']`), and it makes it easier to check and score a participant's response. 
 
-There may be situations when you want key choices and responses to be case-sensitive. You can change this by setting the `case_sensitive` parameter to `true` in `jsPsych.init`.
+There may be situations when you want key choices and responses to be case-sensitive. You can change this by setting the `case_sensitive_responses` parameter to `true` in `jsPsych.init`.
 
 ```js
 // use case-sensitive key choices and responses, 
@@ -116,7 +116,7 @@ There may be situations when you want key choices and responses to be case-sensi
 // and will be recorded this way in the data
 jsPsych.init({
     timeline: [...],
-    case_sensitive: true
+    case_sensitive_responses: true
 });
 ```
 


### PR DESCRIPTION
Updated docs on "Choose whether you want keyboard choices/responses to be case-sensitive", where the mentioned "case_sensitive" parameter must be "case_sensitive_responses" instead, as it is otherwise correctly implemented and mentioned in other places in the documentation (e.g. "jspsych-pluginAPI.md" - starting at line 112 and "jspsych-core.md" at line 368). The "case_sensitive" variable is used only internally (e.g. "jspsych.js" - lines 2273 and 2411), but not exposed to the "jsPsych.init" method when creating an experiment. Tested with the latest release (6.3.1) with the "jspsych-html-keyboard-response" plugin and I can verify that by following the old documentation it doesn't work (for obvious reasons), but following the one I propose here it does work, as initially intended by the developers. Thanks!