### PR TITLE
Add jsPsych Builder reference to docs

### DIFF
--- a/docs/overview/running-experiments.md
+++ b/docs/overview/running-experiments.md
@@ -8,7 +8,10 @@ You can run your jsPsych experiment:
 
 The way that you run your experiment will have consequences for certain aspects about how the experiment works, and what your experiment will be able to do. This page explains what you need to know about both of these options.
 
-
+!!! info
+    If you are looking for a tool to automate deployment-related tasks, check out [jsPsych Builder](https://github.com/bjoluc/jspsych-builder), a CLI utility that helps to get jsPsych deployments right.
+    It automatically bundles scripts and style sheets, configures media preloading, and yields a zip file that contains all files for deployment (online or offline).
+    jsPsych Builder can also directly build JATOS experiment files (.jzip) that you can upload to a JATOS server.
 
 ## Offline
 

--- a/docs/tutorials/hello-world.md
+++ b/docs/tutorials/hello-world.md
@@ -1,13 +1,14 @@
 # jsPsych "Hello world" experiment
 
 In the long tradition of **"Hello world!"** examples, this tutorial creates an experiment that outputs the phrase "Hello world!" to the browser. Though useless as an actual experiment, the process is helpful for learning the basics of using the jsPsych library. This tutorial will assume that you know very little about how to set up a web page.
+If this does not apply to you and you would like to utilize modern JavaScript and NPM, consider using [jsPsych Builder](https://github.com/bjoluc/jspsych-builder) instead to automate the setup, spin up a development server, and later on transpile and bundle scripts and styles.
 
 ## Step 1: Download the jsPsych library
 
 Start by downloading the jsPsych library. The most recent version can always be found on the [GitHub releases page](https://github.com/jspsych/jsPsych/releases).
 
 *Note: the image below shows version 4.2, but the process is the same for the most recent version.*
-
+ 
 ![releasespage](/img/githubreleases.jpg)
 
 !!! warning


### PR DESCRIPTION
Here's my approach to #1855. As I started writing, I noticed a separate section on the overview/running-experiments page would be a bit overkill. Hence, here's only a little info box on that page, and an additional sentence in the hello-world tutorial introduction. Also, there's not really a need for a separate jsPsych Builder hello-world tutorial, as `jspsych init` does it all. Users can simply start with the demo experiment tutorial which I also refer to in the jsPsych Builder readme.