### PR TITLE
Add a demo for the canvas-button-response plugin.

### DIFF
--- a/docs/plugins/demos/jspsych-canvas-button-response-demo.html
+++ b/docs/plugins/demos/jspsych-canvas-button-response-demo.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="https://cdn.jsdelivr.net/gh/jspsych/jsPsych@6.3.1/jspsych.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jspsych/jsPsych@6.3.1/plugins/jspsych-canvas-button-response.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jspsych/jsPsych@6.3.1/plugins/jspsych-html-button-response.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jspsych/jsPsych@6.3.1/css/jspsych.css">
+  <style>
+      .jspsych-btn {margin-bottom: 10px;}
+  </style>
+</head>
+<body></body>
+<script>
+
+  var start = {
+    type: 'html-button-response',
+    stimulus: '',
+    choices: ['Run demo']
+  };
+
+  var show_data = {
+    type: 'html-button-response',
+    stimulus: function() {
+      var trial_data = jsPsych.data.get().filter({trial_type: 'canvas-button-response'}).values();
+      console.log(trial_data)
+      var trial_json = JSON.stringify(trial_data, null, 2);
+      return `<p style="margin-bottom:0px;"><strong>Trial data:</strong></p>
+        <pre style="margin-top:0px;text-align:left;">'${trial_json}</pre>`;
+    },
+    choices: ['Repeat demo']
+  };
+
+
+  // stimulus function that takes the canvas and additional parameters (radius, color)
+  // this can be called inside of an anonymous stimulus function, which takes the canvas (c) as its only argument
+  function filledCirc(canvas, radius, color) {
+    var ctx = canvas.getContext("2d");
+    ctx.beginPath();
+    ctx.arc(250, 250, radius, 0, 2 * Math.PI);
+    ctx.fillStyle = color;
+    ctx.fill();
+  }
+
+  var circle_1 = {
+    type: 'canvas-button-response',
+    stimulus: function(c) {
+      filledCirc(c, 100, 'blue');
+    },
+    choices: ['Red', 'Green', 'Blue'],
+    prompt: '<p>What color is the circle?</p>',
+    data: {color: 'blue', radius: 100}
+  };
+
+  var circle_2 = {
+    type: 'canvas-button-response',
+    stimulus: function(c) {
+      filledCirc(c, 150, 'green');
+    },
+    choices: ['Larger', 'Smaller'],
+    stimulus_duration: 1000,
+    prompt: '<p>Is this circle larger or smaller than the last one?</p>'+
+      '<p>Stimulus will be hidden after 1 second.</p>',
+    data: {color: 'green', radius: 150}
+  };
+
+  // write the canvas stimulus drawing function without using a named function
+  // the anonymous function must take the canvas as an argument
+  var lines = {
+    type: 'canvas-button-response',
+    stimulus: function(c) {
+      var ctx = c.getContext("2d");
+      // first line
+      ctx.beginPath();
+      ctx.moveTo(300, 10);
+      ctx.lineTo(300, 300);
+      ctx.lineWidth = 10;
+      ctx.strokeStyle = 'MediumBlue';
+      ctx.stroke();
+      // second line
+      ctx.beginPath();
+      ctx.moveTo(20, 200);
+      ctx.lineTo(100, 350);
+      ctx.lineWidth = 10;
+      ctx.strokeStyle = 'MediumPurple';
+      ctx.stroke();
+    },
+    choices: ['Blue line', 'Purple line'],
+    prompt: '<p>Which line is longer?</p>',
+    data: {line1_color: 'blue', line1_length: 290, line2_color: "purple", line2_length: 170}
+  };
+
+  // to use the canvas stimulus function with timeline variables,
+  // the jsPsych.timelineVariable() function can be used inside your stimulus function
+  var circle_procedure = {
+    timeline: [{
+      type: 'canvas-button-response',
+      stimulus: function(c) {
+          filledCirc(c, jsPsych.timelineVariable('radius'), jsPsych.timelineVariable('color'));
+      },
+      choices: ['Red', 'Green', 'Blue'],
+      prompt: '<p>What color is the circle?</p>',
+      data: {radius: jsPsych.timelineVariable('radius'), color: jsPsych.timelineVariable('color')}
+    }],
+    timeline_variables: [
+      {radius: 100, color: 'red'},
+      {radius: 200, color: 'green'},
+      {radius: 50, color: 'blue'}
+    ]
+  };
+
+  var canvas_data_loop = {
+    timeline: [circle_1, circle_2, lines, circle_procedure, show_data],
+    loop_function: function() {
+      return true;
+    }
+  };
+
+  if (typeof jsPsych !== "undefined") {
+    jsPsych.init({
+      timeline: [start, canvas_data_loop]
+    });
+  } else {
+    document.body.innerHTML = '<div style="text-align:center; margin-top:50%; transform:translate(0,-50%);">You must be online to view the plugin demo.</div>';
+  }
+
+</script>
+
+</html>

--- a/docs/plugins/demos/jspsych-canvas-button-response-demo1.html
+++ b/docs/plugins/demos/jspsych-canvas-button-response-demo1.html
@@ -22,10 +22,9 @@
     type: 'html-button-response',
     stimulus: function() {
       var trial_data = jsPsych.data.get().filter({trial_type: 'canvas-button-response'}).values();
-      console.log(trial_data)
       var trial_json = JSON.stringify(trial_data, null, 2);
       return `<p style="margin-bottom:0px;"><strong>Trial data:</strong></p>
-        <pre style="margin-top:0px;text-align:left;">'${trial_json}</pre>`;
+        <pre style="margin-top:0px;text-align:left;">${trial_json}</pre>`;
     },
     choices: ['Repeat demo']
   };
@@ -63,53 +62,8 @@
     data: {color: 'green', radius: 150}
   };
 
-  // write the canvas stimulus drawing function without using a named function
-  // the anonymous function must take the canvas as an argument
-  var lines = {
-    type: 'canvas-button-response',
-    stimulus: function(c) {
-      var ctx = c.getContext("2d");
-      // first line
-      ctx.beginPath();
-      ctx.moveTo(300, 10);
-      ctx.lineTo(300, 300);
-      ctx.lineWidth = 10;
-      ctx.strokeStyle = 'MediumBlue';
-      ctx.stroke();
-      // second line
-      ctx.beginPath();
-      ctx.moveTo(20, 200);
-      ctx.lineTo(100, 350);
-      ctx.lineWidth = 10;
-      ctx.strokeStyle = 'MediumPurple';
-      ctx.stroke();
-    },
-    choices: ['Blue line', 'Purple line'],
-    prompt: '<p>Which line is longer?</p>',
-    data: {line1_color: 'blue', line1_length: 290, line2_color: "purple", line2_length: 170}
-  };
-
-  // to use the canvas stimulus function with timeline variables,
-  // the jsPsych.timelineVariable() function can be used inside your stimulus function
-  var circle_procedure = {
-    timeline: [{
-      type: 'canvas-button-response',
-      stimulus: function(c) {
-          filledCirc(c, jsPsych.timelineVariable('radius'), jsPsych.timelineVariable('color'));
-      },
-      choices: ['Red', 'Green', 'Blue'],
-      prompt: '<p>What color is the circle?</p>',
-      data: {radius: jsPsych.timelineVariable('radius'), color: jsPsych.timelineVariable('color')}
-    }],
-    timeline_variables: [
-      {radius: 100, color: 'red'},
-      {radius: 200, color: 'green'},
-      {radius: 50, color: 'blue'}
-    ]
-  };
-
   var canvas_data_loop = {
-    timeline: [circle_1, circle_2, lines, circle_procedure, show_data],
+    timeline: [circle_1, circle_2, show_data],
     loop_function: function() {
       return true;
     }

--- a/docs/plugins/demos/jspsych-canvas-button-response-demo1.html
+++ b/docs/plugins/demos/jspsych-canvas-button-response-demo1.html
@@ -21,8 +21,9 @@
   var show_data = {
     type: 'html-button-response',
     stimulus: function() {
-      var trial_data = jsPsych.data.get().filter({trial_type: 'canvas-button-response'}).values();
-      var trial_json = JSON.stringify(trial_data, null, 2);
+      var all_trial_data = jsPsych.data.get().filter({trial_type: 'canvas-button-response'});
+      var last_two_data = all_trial_data.last(2).values(); // One block consists of two canvas-button-response trials
+      var trial_json = JSON.stringify(last_two_data, null, 2);
       return `<p style="margin-bottom:0px;"><strong>Trial data:</strong></p>
         <pre style="margin-top:0px;text-align:left;">${trial_json}</pre>`;
     },
@@ -35,7 +36,7 @@
   function filledCirc(canvas, radius, color) {
     var ctx = canvas.getContext("2d");
     ctx.beginPath();
-    ctx.arc(250, 250, radius, 0, 2 * Math.PI);
+    ctx.arc(150, 150, radius, 0, 2 * Math.PI);
     ctx.fillStyle = color;
     ctx.fill();
   }
@@ -45,6 +46,7 @@
     stimulus: function(c) {
       filledCirc(c, 100, 'blue');
     },
+    canvas_size: [300, 300],
     choices: ['Red', 'Green', 'Blue'],
     prompt: '<p>What color is the circle?</p>',
     data: {color: 'blue', radius: 100}
@@ -55,6 +57,7 @@
     stimulus: function(c) {
       filledCirc(c, 150, 'green');
     },
+    canvas_size: [300, 300],
     choices: ['Larger', 'Smaller'],
     stimulus_duration: 1000,
     prompt: '<p>Is this circle larger or smaller than the last one?</p>'+

--- a/docs/plugins/demos/jspsych-canvas-button-response-demo2.html
+++ b/docs/plugins/demos/jspsych-canvas-button-response-demo2.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="https://cdn.jsdelivr.net/gh/jspsych/jsPsych@6.3.1/jspsych.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jspsych/jsPsych@6.3.1/plugins/jspsych-canvas-button-response.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jspsych/jsPsych@6.3.1/plugins/jspsych-html-button-response.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jspsych/jsPsych@6.3.1/css/jspsych.css">
+  <style>
+      .jspsych-btn {margin-bottom: 10px;}
+  </style>
+</head>
+<body></body>
+<script>
+
+  var start = {
+    type: 'html-button-response',
+    stimulus: '',
+    choices: ['Run demo']
+  };
+
+  var show_data = {
+    type: 'html-button-response',
+    stimulus: function() {
+      var trial_data = jsPsych.data.get().filter({trial_type: 'canvas-button-response'}).values();
+      var trial_json = JSON.stringify(trial_data, null, 2);
+      return `<p style="margin-bottom:0px;"><strong>Trial data:</strong></p>
+        <pre style="margin-top:0px;text-align:left;">${trial_json}</pre>`;
+    },
+    choices: ['Repeat demo']
+  };
+
+  // write the canvas stimulus drawing function without using a named function
+  // the anonymous function must take the canvas as an argument
+  var lines = {
+    type: 'canvas-button-response',
+    stimulus: function(c) {
+      var ctx = c.getContext("2d");
+      // first line
+      ctx.beginPath();
+      ctx.moveTo(300, 10);
+      ctx.lineTo(300, 300);
+      ctx.lineWidth = 10;
+      ctx.strokeStyle = 'MediumBlue';
+      ctx.stroke();
+      // second line
+      ctx.beginPath();
+      ctx.moveTo(20, 200);
+      ctx.lineTo(100, 350);
+      ctx.lineWidth = 10;
+      ctx.strokeStyle = 'MediumPurple';
+      ctx.stroke();
+    },
+    choices: ['Blue line', 'Purple line'],
+    prompt: '<p>Which line is longer?</p>',
+    data: {line1_color: 'blue', line1_length: 290, line2_color: "purple", line2_length: 170}
+  };
+
+  var canvas_data_loop = {
+    timeline: [lines, show_data],
+    loop_function: function() {
+      return true;
+    }
+  };
+
+  if (typeof jsPsych !== "undefined") {
+    jsPsych.init({
+      timeline: [start, canvas_data_loop]
+    });
+  } else {
+    document.body.innerHTML = '<div style="text-align:center; margin-top:50%; transform:translate(0,-50%);">You must be online to view the plugin demo.</div>';
+  }
+
+</script>
+
+</html>

--- a/docs/plugins/demos/jspsych-canvas-button-response-demo2.html
+++ b/docs/plugins/demos/jspsych-canvas-button-response-demo2.html
@@ -21,7 +21,7 @@
   var show_data = {
     type: 'html-button-response',
     stimulus: function() {
-      var trial_data = jsPsych.data.get().filter({trial_type: 'canvas-button-response'}).values();
+      var trial_data = jsPsych.data.getLastTrialData().values();
       var trial_json = JSON.stringify(trial_data, null, 2);
       return `<p style="margin-bottom:0px;"><strong>Trial data:</strong></p>
         <pre style="margin-top:0px;text-align:left;">${trial_json}</pre>`;
@@ -37,19 +37,20 @@
       var ctx = c.getContext("2d");
       // first line
       ctx.beginPath();
-      ctx.moveTo(300, 10);
-      ctx.lineTo(300, 300);
+      ctx.moveTo(200, 10);
+      ctx.lineTo(200, 250);
       ctx.lineWidth = 10;
       ctx.strokeStyle = 'MediumBlue';
       ctx.stroke();
       // second line
       ctx.beginPath();
-      ctx.moveTo(20, 200);
-      ctx.lineTo(100, 350);
+      ctx.moveTo(20, 100);
+      ctx.lineTo(100, 250);
       ctx.lineWidth = 10;
       ctx.strokeStyle = 'MediumPurple';
       ctx.stroke();
     },
+    canvas_size: [300, 300],
     choices: ['Blue line', 'Purple line'],
     prompt: '<p>Which line is longer?</p>',
     data: {line1_color: 'blue', line1_length: 290, line2_color: "purple", line2_length: 170}

--- a/docs/plugins/demos/jspsych-canvas-button-response-demo3.html
+++ b/docs/plugins/demos/jspsych-canvas-button-response-demo3.html
@@ -21,8 +21,9 @@
   var show_data = {
     type: 'html-button-response',
     stimulus: function() {
-      var trial_data = jsPsych.data.get().filter({trial_type: 'canvas-button-response'}).values();
-      var trial_json = JSON.stringify(trial_data, null, 2);
+      var all_trial_data = jsPsych.data.get().filter({trial_type: 'canvas-button-response'});
+      var last_three_data = all_trial_data.last(3).values(); // One block consists of three canvas-button-response trials
+      var trial_json = JSON.stringify(last_three_data, null, 2);
       return `<p style="margin-bottom:0px;"><strong>Trial data:</strong></p>
         <pre style="margin-top:0px;text-align:left;">${trial_json}</pre>`;
     },
@@ -32,7 +33,7 @@
   function filledCirc(canvas, radius, color) {
     var ctx = canvas.getContext("2d");
     ctx.beginPath();
-    ctx.arc(250, 250, radius, 0, 2 * Math.PI);
+    ctx.arc(150, 150, radius, 0, 2 * Math.PI);
     ctx.fillStyle = color;
     ctx.fill();
   }
@@ -46,6 +47,7 @@
       stimulus: function(c) {
           filledCirc(c, jsPsych.timelineVariable('radius'), jsPsych.timelineVariable('color'));
       },
+      canvas_size: [300, 300],
       choices: ['Red', 'Green', 'Blue'],
       prompt: '<p>What color is the circle?</p>',
       data: {
@@ -57,8 +59,8 @@
       }
     }],
     timeline_variables: [
-      {radius: 100, color: 'red', correct_response: 0},
-      {radius: 200, color: 'green', correct_response: 1},
+      {radius: 80, color: 'red', correct_response: 0},
+      {radius: 100, color: 'green', correct_response: 1},
       {radius: 50, color: 'blue', correct_response: 2}
     ],
     randomize_order: true

--- a/docs/plugins/demos/jspsych-canvas-button-response-demo3.html
+++ b/docs/plugins/demos/jspsych-canvas-button-response-demo3.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="https://cdn.jsdelivr.net/gh/jspsych/jsPsych@6.3.1/jspsych.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jspsych/jsPsych@6.3.1/plugins/jspsych-canvas-button-response.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jspsych/jsPsych@6.3.1/plugins/jspsych-html-button-response.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jspsych/jsPsych@6.3.1/css/jspsych.css">
+  <style>
+      .jspsych-btn {margin-bottom: 10px;}
+  </style>
+</head>
+<body></body>
+<script>
+
+  var start = {
+    type: 'html-button-response',
+    stimulus: '',
+    choices: ['Run demo']
+  };
+
+  var show_data = {
+    type: 'html-button-response',
+    stimulus: function() {
+      var trial_data = jsPsych.data.get().filter({trial_type: 'canvas-button-response'}).values();
+      var trial_json = JSON.stringify(trial_data, null, 2);
+      return `<p style="margin-bottom:0px;"><strong>Trial data:</strong></p>
+        <pre style="margin-top:0px;text-align:left;">${trial_json}</pre>`;
+    },
+    choices: ['Repeat demo']
+  };
+
+  function filledCirc(canvas, radius, color) {
+    var ctx = canvas.getContext("2d");
+    ctx.beginPath();
+    ctx.arc(250, 250, radius, 0, 2 * Math.PI);
+    ctx.fillStyle = color;
+    ctx.fill();
+  }
+
+  // To use the canvas stimulus function with timeline variables,
+  // the jsPsych.timelineVariable() function can be used inside your stimulus function.
+  // In addition, this code demonstrates how to check whether participants' answers were correct or not.
+  var circle_procedure = {
+    timeline: [{
+      type: 'canvas-button-response',
+      stimulus: function(c) {
+          filledCirc(c, jsPsych.timelineVariable('radius'), jsPsych.timelineVariable('color'));
+      },
+      choices: ['Red', 'Green', 'Blue'],
+      prompt: '<p>What color is the circle?</p>',
+      data: {
+        radius: jsPsych.timelineVariable('radius'), 
+        color: jsPsych.timelineVariable('color'),
+        correct_response: jsPsych.timelineVariable('correct_response')},
+      on_finish: function(data){
+        data.correct = jsPsych.pluginAPI.compareKeys(data.response, data.correct_response);
+      }
+    }],
+    timeline_variables: [
+      {radius: 100, color: 'red', correct_response: 0},
+      {radius: 200, color: 'green', correct_response: 1},
+      {radius: 50, color: 'blue', correct_response: 2}
+    ],
+    randomize_order: true
+  };
+
+  var canvas_data_loop = {
+    timeline: [circle_procedure, show_data],
+    loop_function: function() {
+      return true;
+    }
+  };
+
+  if (typeof jsPsych !== "undefined") {
+    jsPsych.init({
+      timeline: [start, canvas_data_loop]
+    });
+  } else {
+    document.body.innerHTML = '<div style="text-align:center; margin-top:50%; transform:translate(0,-50%);">You must be online to view the plugin demo.</div>';
+  }
+
+</script>
+
+</html>

--- a/docs/plugins/jspsych-animation.md
+++ b/docs/plugins/jspsych-animation.md
@@ -43,8 +43,8 @@ response | array | An array, where each element is an object representing a resp
 
     === "Demo"
         <div style="text-align:center;">
-            <iframe src="../demos/jspsych-animation-demo.html" width="90%;" height="500px;" frameBorder="0"></iframe>
+            <iframe src="../plugins/demos/jspsych-animation-demo.html" width="90%;" height="500px;" frameBorder="0"></iframe>
         </div>
 
         
-    <a target="_blank" rel="noopener noreferrer" href="../demos/jspsych-animation-demo.html">Open demo in new tab</a>
+    <a target="_blank" rel="noopener noreferrer" href="../plugins/demos/jspsych-animation-demo.html">Open demo in new tab</a>

--- a/docs/plugins/jspsych-canvas-button-response.md
+++ b/docs/plugins/jspsych-canvas-button-response.md
@@ -64,3 +64,59 @@ var circle_2 = {
 };
 
 ```
+
+### Using an anonymous stimulus function
+
+```javascript
+var lines = {
+    type: 'canvas-button-response',
+    stimulus: function(c) {
+      var ctx = c.getContext("2d");
+      // first line
+      ctx.beginPath();
+      ctx.moveTo(300, 10);
+      ctx.lineTo(300, 300);
+      ctx.lineWidth = 10;
+      ctx.strokeStyle = 'MediumBlue';
+      ctx.stroke();
+      // second line
+      ctx.beginPath();
+      ctx.moveTo(20, 200);
+      ctx.lineTo(100, 350);
+      ctx.lineWidth = 10;
+      ctx.strokeStyle = 'MediumPurple';
+      ctx.stroke();
+    },
+    choices: ['Blue line', 'Purple line'],
+    prompt: '<p>Which line is longer?</p>',
+    data: {line1_color: 'blue', line1_length: 290, line2_color: "purple", line2_length: 170}
+  };
+```
+
+### Using the canvas stimulus function with timeline variables, and recording the correctness of responses
+
+```javascript
+var circle_procedure = {
+    timeline: [{
+      type: 'canvas-button-response',
+      stimulus: function(c) {
+          filledCirc(c, jsPsych.timelineVariable('radius'), jsPsych.timelineVariable('color'));
+      },
+      choices: ['Red', 'Green', 'Blue'],
+      prompt: '<p>What color is the circle?</p>',
+      data: {
+        radius: jsPsych.timelineVariable('radius'), 
+        color: jsPsych.timelineVariable('color'),
+        correct_response: jsPsych.timelineVariable('correct_response')},
+      on_finish: function(data){
+        data.correct = jsPsych.pluginAPI.compareKeys(data.response, data.correct_response);
+      }
+    }],
+    timeline_variables: [
+      {radius: 100, color: 'red', correct_response: 0},
+      {radius: 200, color: 'green', correct_response: 1},
+      {radius: 50, color: 'blue', correct_response: 2}
+    ],
+    randomize_order: true
+  };
+```

--- a/docs/plugins/jspsych-canvas-button-response.md
+++ b/docs/plugins/jspsych-canvas-button-response.md
@@ -32,91 +32,126 @@ Note: the canvas stimulus is *not* included in the trial data because it is a fu
 
 ## Examples
 
-### Drawing circles based on parameters
+???+ example "Drawing circles based on parameters"
+    === "Code"
+        ```javascript
+        function filledCirc(canvas, radius, color) {
+            var ctx = canvas.getContext("2d");
+            ctx.beginPath();
+            ctx.arc(150, 150, radius, 0, 2 * Math.PI);
+            ctx.fillStyle = color;
+            ctx.fill();
+        }
 
-```javascript
-function filledCirc(canvas, radius, color){
-    var ctx = canvas.getContext("2d");
-    ctx.beginPath();
-    ctx.arc(250, 250, radius, 0, 2 * Math.PI);
-    ctx.fillStyle = color;
-    ctx.fill()
-}
+        var circle_1 = {
+            type: 'canvas-button-response',
+            stimulus: function(c) {
+            filledCirc(c, 100, 'blue');
+            },
+            canvas_size: [300, 300],
+            choices: ['Red', 'Green', 'Blue'],
+            prompt: '<p>What color is the circle?</p>',
+            data: {color: 'blue', radius: 100}
+        };
 
-var circle_1 = {
-    type: 'canvas-button-response',
-    stimulus: function (c) {
-        filledCirc(c, 100, 'blue');
-    },
-    choices: ['Red', 'Green', 'Blue'],
-    prompt: '<p>What color is the circle?</p>',
-    data: {color: 'blue', radius: 100}
-};
+        var circle_2 = {
+            type: 'canvas-button-response',
+            stimulus: function(c) {
+            filledCirc(c, 150, 'green');
+            },
+            canvas_size: [300, 300],
+            choices: ['Larger', 'Smaller'],
+            stimulus_duration: 1000,
+            prompt: '<p>Is this circle larger or smaller than the last one?</p>'+
+            '<p>Stimulus will be hidden after 1 second.</p>',
+            data: {color: 'green', radius: 150}
+        };
+        ```
 
-var circle_2 = {
-    type: 'canvas-button-response',
-    stimulus: function (c) {
-        filledCirc(c, 150, 'green');
-    },
-    choices: ['Larger', 'Smaller'],
-    prompt: '<p>Is this circle larger or smaller than the last one?</p>',
-    data: {color: 'green', radius: 150}
-};
+    === "Demo"
+        <div style="text-align:center;">
+            <iframe src="../plugins/demos/jspsych-canvas-button-response-demo1.html" width="90%;" height="500px;" frameBorder="0"></iframe>
+        </div>
 
-```
+    <a target="_blank" rel="noopener noreferrer" href="../plugins/demos/jspsych-canvas-button-response-demo1.html">Open demo in new tab</a>
 
-### Using an anonymous stimulus function
+???+ example "Using an anonymous stimulus function"
+    === "Code"
+        ```javascript
+        var lines = {
+            type: 'canvas-button-response',
+            stimulus: function(c) {
+            var ctx = c.getContext("2d");
+            // first line
+            ctx.beginPath();
+            ctx.moveTo(200, 10);
+            ctx.lineTo(200, 250);
+            ctx.lineWidth = 10;
+            ctx.strokeStyle = 'MediumBlue';
+            ctx.stroke();
+            // second line
+            ctx.beginPath();
+            ctx.moveTo(20, 100);
+            ctx.lineTo(100, 250);
+            ctx.lineWidth = 10;
+            ctx.strokeStyle = 'MediumPurple';
+            ctx.stroke();
+            },
+            canvas_size: [300, 300],
+            choices: ['Blue line', 'Purple line'],
+            prompt: '<p>Which line is longer?</p>',
+            data: {line1_color: 'blue', line1_length: 290, line2_color: "purple", line2_length: 170}
+        };
+        ```
 
-```javascript
-var lines = {
-    type: 'canvas-button-response',
-    stimulus: function(c) {
-      var ctx = c.getContext("2d");
-      // first line
-      ctx.beginPath();
-      ctx.moveTo(300, 10);
-      ctx.lineTo(300, 300);
-      ctx.lineWidth = 10;
-      ctx.strokeStyle = 'MediumBlue';
-      ctx.stroke();
-      // second line
-      ctx.beginPath();
-      ctx.moveTo(20, 200);
-      ctx.lineTo(100, 350);
-      ctx.lineWidth = 10;
-      ctx.strokeStyle = 'MediumPurple';
-      ctx.stroke();
-    },
-    choices: ['Blue line', 'Purple line'],
-    prompt: '<p>Which line is longer?</p>',
-    data: {line1_color: 'blue', line1_length: 290, line2_color: "purple", line2_length: 170}
-  };
-```
+    === "Demo"
+        <div style="text-align:center;">
+            <iframe src="../plugins/demos/jspsych-canvas-button-response-demo2.html" width="90%;" height="500px;" frameBorder="0"></iframe>
+        </div>
 
-### Using the canvas stimulus function with timeline variables, and recording the correctness of responses
+    <a target="_blank" rel="noopener noreferrer" href="../plugins/demos/jspsych-canvas-button-response-demo2.html">Open demo in new tab</a>
 
-```javascript
-var circle_procedure = {
-    timeline: [{
-      type: 'canvas-button-response',
-      stimulus: function(c) {
-          filledCirc(c, jsPsych.timelineVariable('radius'), jsPsych.timelineVariable('color'));
-      },
-      choices: ['Red', 'Green', 'Blue'],
-      prompt: '<p>What color is the circle?</p>',
-      data: {
-        radius: jsPsych.timelineVariable('radius'), 
-        color: jsPsych.timelineVariable('color'),
-        correct_response: jsPsych.timelineVariable('correct_response')},
-      on_finish: function(data){
-        data.correct = jsPsych.pluginAPI.compareKeys(data.response, data.correct_response);
-      }
-    }],
-    timeline_variables: [
-      {radius: 100, color: 'red', correct_response: 0},
-      {radius: 200, color: 'green', correct_response: 1},
-      {radius: 50, color: 'blue', correct_response: 2}
-    ],
-    randomize_order: true
-  };
-```
+
+???+ example "Using the canvas stimulus function with timeline variables, and recording the correctness of responses"
+    === "Code"
+        ```javascript
+        function filledCirc(canvas, radius, color) {
+            var ctx = canvas.getContext("2d");
+            ctx.beginPath();
+            ctx.arc(150, 150, radius, 0, 2 * Math.PI);
+            ctx.fillStyle = color;
+            ctx.fill();
+        }
+
+        var circle_procedure = {
+            timeline: [{
+            type: 'canvas-button-response',
+            stimulus: function(c) {
+                filledCirc(c, jsPsych.timelineVariable('radius'), jsPsych.timelineVariable('color'));
+            },
+            canvas_size: [300, 300],
+            choices: ['Red', 'Green', 'Blue'],
+            prompt: '<p>What color is the circle?</p>',
+            data: {
+                radius: jsPsych.timelineVariable('radius'), 
+                color: jsPsych.timelineVariable('color'),
+                correct_response: jsPsych.timelineVariable('correct_response')},
+            on_finish: function(data){
+                data.correct = jsPsych.pluginAPI.compareKeys(data.response, data.correct_response);
+            }
+            }],
+            timeline_variables: [
+            {radius: 80, color: 'red', correct_response: 0},
+            {radius: 100, color: 'green', correct_response: 1},
+            {radius: 50, color: 'blue', correct_response: 2}
+            ],
+            randomize_order: true
+        };        
+        ```
+
+    === "Demo"
+        <div style="text-align:center;">
+            <iframe src="../plugins/demos/jspsych-canvas-button-response-demo3.html" width="90%;" height="500px;" frameBorder="0"></iframe>
+        </div>
+
+    <a target="_blank" rel="noopener noreferrer" href="../plugins/demos/jspsych-canvas-button-response-demo3.html">Open demo in new tab</a>


### PR DESCRIPTION
I've made a demo for the canvas-button-response plugin.
The code is almost identical to examples/jspsych-canvas-button-response.html, rather than my own creation. Is there any problem?

One thing I'm a little concerned about is that the data output screen shows a single quotation. 
![スクリーンショット 2021-06-29 142528](https://user-images.githubusercontent.com/32691644/123741970-eb328880-d8e5-11eb-85b9-c369317748d4.png)

Do you know the cause of this?
