### PR TITLE
Modified Visual Search Circle Plugin

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -38,6 +38,7 @@ The following people have contributed to the development of jsPsych by writing c
 * Vijay Marupudi - https://github.com/vijaymarupudi
 * Adrian Oesch - https://github.com/adrianoesch
 * Benjamin Ooghe-Tabanou - https://github.com/boogheta
+* Keshav Pabbi - https://github.com/keshavpabbi
 * Nikolay B Petrov - https://github.com/nikbpetrov
 * Dillon Plunkett - https://github.com/dillonplunkett
 * Junyan Qi - https://github.com/GavinQ1

--- a/examples/jspsych-visual-search.html
+++ b/examples/jspsych-visual-search.html
@@ -6,7 +6,7 @@
   <script src="js/snap.svg-min.js"></script>
   <script src="../jspsych.js"></script>
   <script src="../plugins/jspsych-html-keyboard-response.js"></script>
-  <script src="../plugins/jspsych-visual-search-circle.js"></script>
+  <script src="../plugins/jspsych-visual-search.js"></script>
   <script src="../plugins/jspsych-preload.js"></script>
   <link rel="stylesheet" href="../css/jspsych.css">
 </head>
@@ -44,17 +44,32 @@
     set_size: 3
   }
 
+  var trial_5 = {
+    usegrid: true,
+    target_present: false,
+    foil: ['img/1.gif', 'img/2.gif', 'img/3.gif'], // example of using multiple foils.
+    set_size: 3
+  }
 
-  var trials = {
-    type: 'visual-search-circle',
+  var trials_circle = {
+    type: 'visual-search',
     target: 'img/backwardN.gif',
     foil: 'img/normalN.gif',
     fixation_image: 'img/fixation.gif',
-    timeline: [trial_1, trial_2, trial_3, trial_4]
+    timeline: [trial_1, trial_2, trial_3, trial_4, trial_5]
+  };
+
+  var trials_grid = {
+    usegrid: true,
+    type: 'visual-search',
+    target: 'img/backwardN.gif',
+    foil: 'img/normalN.gif',
+    fixation_image: 'img/fixation.gif',
+    timeline: [trial_1, trial_2, trial_3, trial_4, trial_5]
   };
 
   jsPsych.init({
-    timeline: [preload_images, intro, trials],
+    timeline: [preload_images, intro, trials_circle, trials_grid],
     on_finish: function() {
       jsPsych.data.displayData();
     }

--- a/plugins/jspsych-visual-search.js
+++ b/plugins/jspsych-visual-search.js
@@ -1,6 +1,6 @@
 /**
  *
- * jspsych-visual-search-circle
+ * jspsych-visual-search
  * Josh de Leeuw
  *
  * display a set of objects, with or without a target, equidistant from fixation
@@ -12,18 +12,30 @@
  *
  **/
 
-jsPsych.plugins["visual-search-circle"] = (function() {
+jsPsych.plugins["visual-search"] = (function() {
 
   var plugin = {};
 
-  jsPsych.pluginAPI.registerPreload('visual-search-circle', 'target', 'image');
-  jsPsych.pluginAPI.registerPreload('visual-search-circle', 'foil', 'image');
-  jsPsych.pluginAPI.registerPreload('visual-search-circle', 'fixation_image', 'image');
+  jsPsych.pluginAPI.registerPreload('visual-search', 'target', 'image');
+  jsPsych.pluginAPI.registerPreload('visual-search', 'foil', 'image');
+  jsPsych.pluginAPI.registerPreload('visual-search', 'fixation_image', 'image');
 
   plugin.info = {
-    name: 'visual-search-circle',
+    name: 'visual-search',
     description: '',
     parameters: {
+      usegrid: {
+        type: jsPsych.plugins.parameterType.BOOL,
+        pretty_name: 'Use grid',
+        default: false,
+        description: 'Place items on a grid?'
+      },
+      jitter_ratio: {
+        type: jsPsych.plugins.parameterType.FLOAT,
+        pretty_name: 'jitter',
+        default: 0.0,
+        description: 'The distance to jitter the image as ratio of image size (average of x and y).'
+      },
       target: {
         type: jsPsych.plugins.parameterType.IMAGE,
         pretty_name: 'Target',
@@ -71,7 +83,7 @@ jsPsych.plugins["visual-search-circle"] = (function() {
       circle_diameter: {
         type: jsPsych.plugins.parameterType.INT,
         pretty_name: 'Circle diameter',
-        default: 250,
+        default: 500,
         description: 'The diameter of the search array circle in pixels.'
       },
       target_present_key: {
@@ -111,26 +123,67 @@ jsPsych.plugins["visual-search-circle"] = (function() {
     // stimuli width, height
     var stimh = trial.target_size[0];
     var stimw = trial.target_size[1];
+    const jitter = ((stimh + stimw) / 2) * trial.jitter_ratio
     var hstimh = stimh / 2;
     var hstimw = stimw / 2;
 
     // fixation location
     var fix_loc = [Math.floor(paper_size / 2 - trial.fixation_size[0] / 2), Math.floor(paper_size / 2 - trial.fixation_size[1] / 2)];
+    
+    var possible_display_locs = trial.set_size;  
+     
+    let display_locs = [];
 
-    // possible stimulus locations on the circle
-    var display_locs = [];
-    var possible_display_locs = trial.set_size;
-    var random_offset = Math.floor(Math.random() * 360);
-    for (var i = 0; i < possible_display_locs; i++) {
-      display_locs.push([
-        Math.floor(paper_size / 2 + (cosd(random_offset + (i * (360 / possible_display_locs))) * radi) - hstimw),
-        Math.floor(paper_size / 2 - (sind(random_offset + (i * (360 / possible_display_locs))) * radi) - hstimh)
-      ]);
+    if (trial.usegrid) {
+
+      const num_pos = Math.ceil(Math.sqrt(possible_display_locs))
+      //square root the number of possible display locations
+
+      const step = 2 / (num_pos - 1)
+      //distance between each location
+      console.log(step, num_pos)
+
+      let full_locs = []
+      for (let x = -1; x <= 1; x+=step) {
+        //x is between -1 and 1, increase by value of step each time
+        for (let y = -1; y <= 1; y+=step) {
+          //y is between -1 and 1, increase by value of step each time
+          full_locs.push([
+            Math.floor(paper_size / 2 + (x * radi) - hstimw),
+            //x coord
+            Math.floor(paper_size / 2 + (y * radi) - hstimh)
+            //y coord
+          ]);
+        }
+      }
+
+      full_locs = shuffle(full_locs)
+      display_locs = full_locs.slice(0, possible_display_locs);
+
+      for (let i=0; i < display_locs.length; i++) {
+        let random_angle = Math.floor(Math.random() * 360);
+        let rand_x = Math.floor(cosd(random_angle) * jitter)
+        let rand_y = Math.floor(sind(random_angle) * jitter)
+        display_locs[i][0] += rand_x 
+        display_locs[i][1] += rand_y
+      }
+
+    } else {
+
+      // possible stimulus locations on the circle
+      var random_offset = Math.floor(Math.random() * 360);
+      for (var i = 0; i < possible_display_locs; i++) {
+        let vec_jitter = Math.sign(Math.random() * 2 - 1) * jitter
+        display_locs.push([
+          Math.floor(paper_size / 2 + (cosd(random_offset + (i * (360 / possible_display_locs))) * (radi + vec_jitter)) - hstimw),
+          Math.floor(paper_size / 2 - (sind(random_offset + (i * (360 / possible_display_locs))) * (radi + vec_jitter)) - hstimh)
+        ]);
+      }
     }
 
     // get target to draw on
-    display_element.innerHTML += '<div id="jspsych-visual-search-circle-container" style="position: relative; width:' + paper_size + 'px; height:' + paper_size + 'px"></div>';
-    var paper = display_element.querySelector("#jspsych-visual-search-circle-container");
+    display_element.innerHTML += '<div id="jspsych-visual-search-container" style="position: relative; width:' + paper_size + 'px; height:' + paper_size + 'px"></div>';
+    var paper = display_element.querySelector("#jspsych-visual-search-container");
 
     // check distractors - array?
     if(!Array.isArray(trial.foil)){
@@ -152,6 +205,7 @@ jsPsych.plugins["visual-search-circle"] = (function() {
       jsPsych.pluginAPI.setTimeout(function() {
         // after wait is over
         show_search_array();
+        paper.innerHTML += "<img src='"+trial.fixation_image+"' style='position: absolute; top:"+fix_loc[0]+"px; left:"+fix_loc[1]+"px; width:"+trial.fixation_size[0]+"px; height:"+trial.fixation_size[1]+"px;'></img>";
       }, trial.fixation_duration);
     }
 
@@ -255,5 +309,24 @@ jsPsych.plugins["visual-search-circle"] = (function() {
     return Math.sin(num / 180 * Math.PI);
   }
 
+  // shuffle any input array
+  function shuffle(array) {
+    // define three variables
+    let cur_idx = array.length, tmp_val, rand_idx;
+
+    // While there remain elements to shuffle...
+    while (0 !== cur_idx) {
+      // Pick a remaining element...
+      rand_idx = Math.floor(Math.random() * cur_idx);
+      cur_idx -= 1;
+
+      // And swap it with the current element.
+      tmp_val = array[cur_idx];
+      array[cur_idx] = array[rand_idx];
+      array[rand_idx] = tmp_val;
+    }
+    return array;
+  }
+  
   return plugin;
 })();


### PR DESCRIPTION
I have replaced the visual-search-circle plugin with a modified version of the plugin called visual-search. This plugin allows experimenters to run a visual search experiment with images placed on a grid if they choose not to use the circle format. I have also added a jitter parameter that can be used by experimenters.

(jitter_ratio and usegrid are the 2 parameters I have added to the visual-search plugin)