### PR TITLE
survey-multi-choice table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Thumbs.db
 /.project
 /.tern-project
 site/
+.vs/


### PR DESCRIPTION
This is a proposal for tabular feature of the `survey-multi-choice` trial.

When `prompt` is an array, the updated `survey-multi-choice` will render a table of radio buttons, where prompts make rows and options make columns of the table. This is useful for likert-style set of questions:

```js
var trial = {
    type: "survey-multi-choice",
    questions: [
        {
            prompt: [ "I like banana", "I like apple", "I like squirrels" ],
            options: [ "a lot", "kinda", "don't know", "meh", "nope" ]
        }
    ]
};
```

will render

||a lot|kinda|don't know|meh|nope|
|---|---|---|---|---|---|
|I like banana|◯|◯|◯|◯|◯|
|I like apple|◯|◯|◯|◯|◯|
|I like squirrels|◯|◯|◯|◯|◯|

with `response` containing array of option values, e.g. `[ "nope", "nope", "a lot" ]`

Existing functionality (e.g. `prompt` and `result` are strings rather than arrays) are still valid and retained without breaking changes.

Happy to consider different approaches if desired.