### PR TITLE
Implement `preload` flag for plugin parameters

### DIFF
--- a/packages/jspsych/src/JsPsych.ts
+++ b/packages/jspsych/src/JsPsych.ts
@@ -170,6 +170,13 @@ export class JsPsych {
 
     document.documentElement.setAttribute("jspsych", "present");
 
+    // Register preloading for the plugins referenced in the timeline
+    for (const [pluginName, parameters] of this.timeline.extractPreloadParameters()) {
+      for (const [parameter, type] of Object.entries(parameters)) {
+        this.pluginAPI.registerPreload(pluginName, parameter, type);
+      }
+    }
+
     this.startExperiment();
     await this.finished;
   }

--- a/packages/jspsych/src/TimelineNode.ts
+++ b/packages/jspsych/src/TimelineNode.ts
@@ -1,4 +1,5 @@
 import { JsPsych } from "./JsPsych";
+import { parameterType } from "./modules/plugins";
 import {
   repeat,
   sampleWithReplacement,
@@ -532,5 +533,55 @@ export class TimelineNode {
         )
       );
     }
+  }
+
+  /**
+   * Extracts a map that, for each of the timeline's (nested) plugins, maps the plugin name to an
+   * object that maps media parameters to their corresponding `preload` type, if not prevented by a
+   * `preload: false` flag in a parameter's description.
+   */
+  extractPreloadParameters() {
+    type PreloadType = "audio" | "image" | "video";
+    const preloadMap = new Map<string, Record<string, PreloadType>>();
+
+    /** Maps parameter types to their corresponding preload type */
+    const parameterTypeMap = new Map<number, PreloadType>([
+      [parameterType.AUDIO, "audio"],
+      [parameterType.IMAGE, "image"],
+      [parameterType.VIDEO, "video"],
+    ]);
+
+    function recurseTimeline(node: TimelineNode) {
+      const isTimeline = typeof node.timeline_parameters !== "undefined";
+
+      if (isTimeline) {
+        for (const childNode of node.timeline_parameters.timeline) {
+          recurseTimeline(childNode);
+        }
+      } else if (node.trial_parameters.type.info) {
+        // node is a trial with type.info set
+
+        // Get the plugin name and parameters object from the info object
+        const { name: pluginName, parameters } = node.trial_parameters.type.info;
+
+        if (!preloadMap.has(pluginName)) {
+          preloadMap.set(
+            pluginName,
+            Object.fromEntries(
+              Object.entries<any>(parameters)
+                // Filter out parameter entries with media types and a non-false `preload` option
+                .filter(
+                  ([_name, { type, preload }]) => parameterTypeMap.has(type) && (preload ?? true)
+                )
+                // Map each entry's value to its preload type
+                .map(([name, { type }]) => [name, parameterTypeMap.get(type)])
+            )
+          );
+        }
+      }
+    }
+
+    recurseTimeline(this);
+    return preloadMap;
   }
 }

--- a/packages/jspsych/src/modules/plugins.ts
+++ b/packages/jspsych/src/modules/plugins.ts
@@ -47,14 +47,15 @@ type ParameterTypeMap = {
   13: any; // TIMELINE
 };
 
-interface ParameterInfo {
+export interface ParameterInfo {
   type: keyof ParameterTypeMap;
   array?: boolean;
   pretty_name?: string;
   default?: any;
+  preload?: "image" | "video" | "audio";
 }
 
-interface ParameterInfos {
+export interface ParameterInfos {
   [key: string]: ParameterInfo;
 }
 


### PR DESCRIPTION
It defaults to `true` for parameters of type IMAGE, VIDEO, and AUDIO,
and is ignored for any other parameter type.
Example: Using `parameterType.IMAGE` for a parameter `param` in a
plugin named `my-plugin` is equivalent to calling
`jspsych.pluginAPI.registerPreload("my-plugin", "param", "image")`
before `jsPsych.run()`. Setting `preload: false` for the parameter would
disable this invocation.

@jodeleeuw Do you agree with the implementation?