### PR TITLE
Refactor KeyboardListenerAPI

### DIFF
--- a/packages/jspsych/src/JsPsych.ts
+++ b/packages/jspsych/src/JsPsych.ts
@@ -109,7 +109,7 @@ export class JsPsych {
     };
     this.opts = options;
 
-    autoBind(this); // just in case people do weird things with JsPsych methods
+    autoBind(this); // so we can pass JsPsych methods as callbacks and `this` remains the JsPsych instance
 
     this.webaudio_context =
       typeof window !== "undefined" && typeof window.AudioContext !== "undefined"
@@ -419,11 +419,6 @@ export class JsPsych {
     }
     this.DOM_target.className += "jspsych-content";
 
-    // below code resets event listeners that may have lingered from
-    // a previous incomplete experiment loaded in same DOM.
-    this.pluginAPI.reset(options.display_element);
-    // create keyboard event listeners
-    this.pluginAPI.createKeyboardEventListeners(options.display_element);
     // create listeners for user browser interaction
     this.data.createInteractionListeners();
 

--- a/packages/jspsych/src/modules/plugin-api/KeyboardListenerAPI.ts
+++ b/packages/jspsych/src/modules/plugin-api/KeyboardListenerAPI.ts
@@ -125,152 +125,24 @@ export class KeyboardListenerAPI {
     this.listeners.clear();
   }
 
-  convertKeyCharacterToKeyCode(character: string) {
-    console.warn(
-      "Warning: The jsPsych.pluginAPI.convertKeyCharacterToKeyCode function will be removed in future jsPsych releases. " +
-        "We recommend removing this function and using strings to identify/compare keys."
-    );
-    return KeyboardListenerAPI.keylookup[character.toLowerCase()];
-  }
-
-  convertKeyCodeToKeyCharacter(code: number) {
-    console.warn(
-      "Warning: The jsPsych.pluginAPI.convertKeyCodeToKeyCharacter function will be removed in future jsPsych releases. " +
-        "We recommend removing this function and using strings to identify/compare keys."
-    );
-    for (var i in Object.keys(KeyboardListenerAPI.keylookup)) {
-      if (KeyboardListenerAPI.keylookup[Object.keys(KeyboardListenerAPI.keylookup)[i]] == code) {
-        return Object.keys(KeyboardListenerAPI.keylookup)[i];
-      }
-    }
-    return undefined;
-  }
-
-  compareKeys(key1: string | number | null, key2: string | number | null) {
-    if (Number.isFinite(key1) || Number.isFinite(key2)) {
-      // if either value is a numeric keyCode, then convert both to numeric keyCode values and compare (maintained for backwards compatibility)
-      if (typeof key1 == "string") {
-        key1 = this.convertKeyCharacterToKeyCode(key1);
-      }
-      if (typeof key2 == "string") {
-        key2 = this.convertKeyCharacterToKeyCode(key2);
-      }
-      return key1 == key2;
-    } else if (typeof key1 === "string" && typeof key2 === "string") {
-      // if both values are strings, then check whether or not letter case should be converted before comparing (case_sensitive_responses in jsPsych.init)
-      if (this.areResponsesCaseSensitive) {
-        return key1 === key2;
-      } else {
-        return key1.toLowerCase() === key2.toLowerCase();
-      }
-    } else if (
-      (key1 === null && (typeof key2 === "string" || Number.isFinite(key2))) ||
-      (key2 === null && (typeof key1 === "string" || Number.isFinite(key1)))
+  compareKeys(key1: string | null, key2: string | null) {
+    if (
+      (typeof key1 !== "string" && key1 !== null) ||
+      (typeof key2 !== "string" && key2 !== null)
     ) {
-      return false;
-    } else if (key1 === null && key2 === null) {
-      return true;
-    } else {
       console.error(
-        "Error in jsPsych.pluginAPI.compareKeys: arguments must be numeric key codes, key strings, or null."
+        "Error in jsPsych.pluginAPI.compareKeys: arguments must be key strings or null."
       );
       return undefined;
     }
-  }
 
-  static keylookup = {
-    backspace: 8,
-    tab: 9,
-    enter: 13,
-    shift: 16,
-    ctrl: 17,
-    alt: 18,
-    pause: 19,
-    capslock: 20,
-    esc: 27,
-    space: 32,
-    spacebar: 32,
-    " ": 32,
-    pageup: 33,
-    pagedown: 34,
-    end: 35,
-    home: 36,
-    leftarrow: 37,
-    uparrow: 38,
-    rightarrow: 39,
-    downarrow: 40,
-    insert: 45,
-    delete: 46,
-    0: 48,
-    1: 49,
-    2: 50,
-    3: 51,
-    4: 52,
-    5: 53,
-    6: 54,
-    7: 55,
-    8: 56,
-    9: 57,
-    a: 65,
-    b: 66,
-    c: 67,
-    d: 68,
-    e: 69,
-    f: 70,
-    g: 71,
-    h: 72,
-    i: 73,
-    j: 74,
-    k: 75,
-    l: 76,
-    m: 77,
-    n: 78,
-    o: 79,
-    p: 80,
-    q: 81,
-    r: 82,
-    s: 83,
-    t: 84,
-    u: 85,
-    v: 86,
-    w: 87,
-    x: 88,
-    y: 89,
-    z: 90,
-    "0numpad": 96,
-    "1numpad": 97,
-    "2numpad": 98,
-    "3numpad": 99,
-    "4numpad": 100,
-    "5numpad": 101,
-    "6numpad": 102,
-    "7numpad": 103,
-    "8numpad": 104,
-    "9numpad": 105,
-    multiply: 106,
-    plus: 107,
-    minus: 109,
-    decimal: 110,
-    divide: 111,
-    f1: 112,
-    f2: 113,
-    f3: 114,
-    f4: 115,
-    f5: 116,
-    f6: 117,
-    f7: 118,
-    f8: 119,
-    f9: 120,
-    f10: 121,
-    f11: 122,
-    f12: 123,
-    "=": 187,
-    ",": 188,
-    ".": 190,
-    "/": 191,
-    "`": 192,
-    "[": 219,
-    "\\": 220,
-    "]": 221,
-  };
+    if (typeof key1 === "string" && typeof key2 === "string") {
+      // if both values are strings, then check whether or not letter case should be converted before comparing (case_sensitive_responses in jsPsych.init)
+      return this.areResponsesCaseSensitive
+        ? key1 === key2
+        : key1.toLowerCase() === key2.toLowerCase();
+    }
+
+    return key1 === null && key2 === null;
+  }
 }

--- a/packages/jspsych/src/modules/plugin-api/index.ts
+++ b/packages/jspsych/src/modules/plugin-api/index.ts
@@ -11,7 +11,11 @@ export function createJointPluginAPIObject(jsPsych: JsPsych) {
   return Object.assign(
     {},
     ...[
-      new KeyboardListenerAPI(settings.case_sensitive_responses, settings.minimum_valid_rt),
+      new KeyboardListenerAPI(
+        jsPsych.getDisplayContainerElement,
+        settings.case_sensitive_responses,
+        settings.minimum_valid_rt
+      ),
       new TimeoutAPI(),
       new MediaAPI(settings.use_webaudio, jsPsych.webaudio_context),
       new HardwareAPI(),

--- a/packages/jspsych/tests/pluginAPI/pluginapi.test.ts
+++ b/packages/jspsych/tests/pluginAPI/pluginapi.test.ts
@@ -283,12 +283,13 @@ describe("#compareKeys", () => {
 
   test("should return undefined and produce a console warning if either/both arguments are not a string, integer, or null", () => {
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
-    var t1 = jsPsych.pluginAPI.compareKeys({}, "Q");
-    var t2 = jsPsych.pluginAPI.compareKeys(true, null);
-    var t3 = jsPsych.pluginAPI.compareKeys(null, ["Q"]);
-    expect(typeof t1).toBe("undefined");
-    expect(typeof t2).toBe("undefined");
-    expect(typeof t3).toBe("undefined");
+    // @ts-expect-error The compareKeys types forbid this
+    expect(jsPsych.pluginAPI.compareKeys({}, "Q")).toBeUndefined();
+    // @ts-expect-error The compareKeys types forbid this
+    expect(jsPsych.pluginAPI.compareKeys(true, null)).toBeUndefined();
+    // @ts-expect-error The compareKeys types forbid this
+    expect(jsPsych.pluginAPI.compareKeys(null, ["Q"])).toBeUndefined();
+
     expect(console.error).toHaveBeenCalledTimes(3);
     expect(spy.mock.calls).toEqual([
       [

--- a/packages/jspsych/tests/pluginAPI/pluginapi.test.ts
+++ b/packages/jspsych/tests/pluginAPI/pluginapi.test.ts
@@ -237,15 +237,6 @@ describe("#cancelAllKeyboardResponses", () => {
 });
 
 describe("#compareKeys", () => {
-  test("should compare keys regardless of type (old key-keyCode functionality)", () => {
-    expect(jsPsych.pluginAPI.compareKeys("q", 81)).toBe(true);
-    expect(jsPsych.pluginAPI.compareKeys(81, 81)).toBe(true);
-    expect(jsPsych.pluginAPI.compareKeys("q", "Q")).toBe(true);
-    expect(jsPsych.pluginAPI.compareKeys(80, 81)).toBe(false);
-    expect(jsPsych.pluginAPI.compareKeys("q", "1")).toBe(false);
-    expect(jsPsych.pluginAPI.compareKeys("q", 80)).toBe(false);
-  });
-
   test("should be case sensitive when case_sensitive_responses is true", () => {
     var t = {
       type: htmlKeyboardResponse,
@@ -272,10 +263,10 @@ describe("#compareKeys", () => {
     expect(jsPsych.pluginAPI.compareKeys("q", "q")).toBe(true);
   });
 
-  test("should accept null as argument, and return true if both arguments are null, and return false if one argument is null and other is string or numeric", () => {
+  test("should accept null as argument, and return true if both arguments are null, and return false if one argument is null and other is string", () => {
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
     expect(jsPsych.pluginAPI.compareKeys(null, "Q")).toBe(false);
-    expect(jsPsych.pluginAPI.compareKeys(80, null)).toBe(false);
+    expect(jsPsych.pluginAPI.compareKeys("Q", null)).toBe(false);
     expect(jsPsych.pluginAPI.compareKeys(null, null)).toBe(true);
     expect(console.error).not.toHaveBeenCalled();
     spy.mockRestore();
@@ -283,6 +274,7 @@ describe("#compareKeys", () => {
 
   test("should return undefined and produce a console warning if either/both arguments are not a string, integer, or null", () => {
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
     // @ts-expect-error The compareKeys types forbid this
     expect(jsPsych.pluginAPI.compareKeys({}, "Q")).toBeUndefined();
     // @ts-expect-error The compareKeys types forbid this
@@ -291,36 +283,14 @@ describe("#compareKeys", () => {
     expect(jsPsych.pluginAPI.compareKeys(null, ["Q"])).toBeUndefined();
 
     expect(console.error).toHaveBeenCalledTimes(3);
-    expect(spy.mock.calls).toEqual([
-      [
-        "Error in jsPsych.pluginAPI.compareKeys: arguments must be numeric key codes, key strings, or null.",
-      ],
-      [
-        "Error in jsPsych.pluginAPI.compareKeys: arguments must be numeric key codes, key strings, or null.",
-      ],
-      [
-        "Error in jsPsych.pluginAPI.compareKeys: arguments must be numeric key codes, key strings, or null.",
-      ],
-    ]);
+    for (let i = 1; i < 4; i++) {
+      expect(spy).toHaveBeenNthCalledWith(
+        i,
+        "Error in jsPsych.pluginAPI.compareKeys: arguments must be key strings or null."
+      );
+    }
+
     spy.mockRestore();
-  });
-});
-
-describe("#convertKeyCharacterToKeyCode", () => {
-  test("should return the keyCode for a particular character", () => {
-    expect(jsPsych.pluginAPI.convertKeyCharacterToKeyCode("q")).toBe(81);
-    expect(jsPsych.pluginAPI.convertKeyCharacterToKeyCode("1")).toBe(49);
-    expect(jsPsych.pluginAPI.convertKeyCharacterToKeyCode("space")).toBe(32);
-    expect(jsPsych.pluginAPI.convertKeyCharacterToKeyCode("enter")).toBe(13);
-  });
-});
-
-describe("#convertKeyCodeToKeyCharacter", () => {
-  test("should return the keyCode for a particular character", () => {
-    expect(jsPsych.pluginAPI.convertKeyCodeToKeyCharacter(81)).toBe("q");
-    expect(jsPsych.pluginAPI.convertKeyCodeToKeyCharacter(49)).toBe("1");
-    expect(jsPsych.pluginAPI.convertKeyCodeToKeyCharacter(32)).toBe("space");
-    expect(jsPsych.pluginAPI.convertKeyCodeToKeyCharacter(13)).toBe("enter");
   });
 });
 

--- a/packages/jspsych/tests/utils.ts
+++ b/packages/jspsych/tests/utils.ts
@@ -3,7 +3,7 @@ import { setImmediate as flushMicroTasks } from "timers";
 import { JsPsych } from "../src";
 
 export function dispatchEvent(event: Event) {
-  document.querySelector(".jspsych-display-element").dispatchEvent(event);
+  document.body.dispatchEvent(event);
 }
 
 export function keyDown(key: string) {


### PR DESCRIPTION
In an approach to https://github.com/jspsych/jsPsych/projects/6#card-64293394, I recently refactored the `KeyboardListenerAPI` class to type the parameters and clean up the logic quite a bit. I also replaced the two array and object-based solutions for listeners and held keys with ES6 sets, which fit the use case very well and could also improve the performance in scenarios with many listeners.
I'll add some notes as review comments below.