### PR TITLE
Allow `on_finish` to return a `Promise` and delay the `endExperiment` message.

### DIFF
--- a/docs/core_library/jspsych-core.md
+++ b/docs/core_library/jspsych-core.md
@@ -1,4 +1,4 @@
-# The jsPsych core library
+# jsPsych
 
 ---
 ## jsPsych.addNodeToEndOfTimeline
@@ -117,7 +117,7 @@ None.
 
 ### Description
 
-Ends the experiment, skipping all remaining trials.
+Ends the experiment, skipping all remaining trials. If the `on_finish` event handler for `jsPsych` returns a `Promise` then the `end_message` will not be displayed until the promise is resolved.
 
 ### Example
 

--- a/packages/jspsych/src/JsPsych.ts
+++ b/packages/jspsych/src/JsPsych.ts
@@ -466,13 +466,20 @@ export class JsPsych {
   }
 
   private finishExperiment() {
-    if (typeof this.timeline.end_message !== "undefined") {
-      this.DOM_target.innerHTML = this.timeline.end_message;
+    const finish_result = this.opts.on_finish(this.data.get());
+
+    const done_handler = () => {
+      if (typeof this.timeline.end_message !== "undefined") {
+        this.DOM_target.innerHTML = this.timeline.end_message;
+      }
+      this.resolveFinishedPromise();
+    };
+
+    if (finish_result) {
+      Promise.resolve(finish_result).then(done_handler);
+    } else {
+      done_handler();
     }
-
-    this.opts.on_finish(this.data.get());
-
-    this.resolveFinishedPromise();
   }
 
   private nextTrial() {

--- a/packages/jspsych/tests/core/endexperiment.test.ts
+++ b/packages/jspsych/tests/core/endexperiment.test.ts
@@ -1,7 +1,7 @@
 import htmlKeyboardResponse from "@jspsych/plugin-html-keyboard-response";
 
 import { initJsPsych } from "../../src";
-import { pressKey, startTimeline } from "../utils";
+import { flushPromises, pressKey, startTimeline } from "../utils";
 
 test("works on basic timeline", async () => {
   const jsPsych = initJsPsych();
@@ -45,5 +45,49 @@ test("works with looping timeline (#541)", async () => {
   expect(getHTML()).toMatch("trial 1");
   pressKey("a");
   expect(getHTML()).toMatch("the end");
+  await expectFinished();
+});
+
+test("if on_finish returns a Promise, wait for resolve before showing end message", async () => {
+  let resolve_end_experiment;
+
+  const jsPsych = initJsPsych({
+    on_finish: () => {
+      return new Promise((resolve, reject) => {
+        resolve_end_experiment = resolve;
+      });
+    },
+  });
+
+  const timeline = [
+    {
+      type: htmlKeyboardResponse,
+      stimulus: "foo",
+      on_finish: () => {
+        jsPsych.endExperiment("done");
+      },
+    },
+    {
+      type: htmlKeyboardResponse,
+      stimulus: "bar",
+    },
+  ];
+
+  const { getHTML, expectFinished, expectRunning } = await startTimeline(timeline, jsPsych);
+
+  expect(getHTML()).toMatch("foo");
+  pressKey("a");
+  expect(getHTML()).not.toMatch("foo");
+  expect(getHTML()).not.toMatch("bar");
+
+  await expectRunning();
+
+  expect(getHTML()).not.toMatch("done");
+  resolve_end_experiment();
+
+  await flushPromises();
+
+  expect(getHTML()).toMatch("done");
+
   await expectFinished();
 });


### PR DESCRIPTION
When `jsPsych.endExperiment` is called it provides the option of displaying a message on the screen. If the `on_finish` event handler in `initJsPsych()` returns a `Promise` then the message will now display only after the promise has resolved. This is to address a particular use case discussed in #1850. 

This fixes #2050.

@javidalpe: I think this should allow what you need to do for cognition.run, but lemme know if you need a slightly different hook.