### PR TITLE
Change event types for `require_movement` parameter in slider response plugins

### DIFF
--- a/packages/plugin-audio-slider-response/src/index.ts
+++ b/packages/plugin-audio-slider-response/src/index.ts
@@ -235,13 +235,19 @@ class AudioSliderResponsePlugin implements JsPsychPlugin<Info> {
       }
 
       if (trial.require_movement) {
+        const enable_button = () => {
+          display_element.querySelector<HTMLInputElement>(
+            "#jspsych-audio-slider-response-next"
+          ).disabled = false;
+        };
+
         display_element
           .querySelector("#jspsych-audio-slider-response-response")
-          .addEventListener("click", function () {
-            display_element.querySelector<HTMLInputElement>(
-              "#jspsych-audio-slider-response-next"
-            ).disabled = false;
-          });
+          .addEventListener("mousedown", enable_button);
+
+        display_element
+          .querySelector("#jspsych-audio-slider-response-response")
+          .addEventListener("touchstart", enable_button);
       }
 
       display_element

--- a/packages/plugin-canvas-slider-response/src/index.ts
+++ b/packages/plugin-canvas-slider-response/src/index.ts
@@ -193,13 +193,19 @@ class CanvasSliderResponsePlugin implements JsPsychPlugin<Info> {
     };
 
     if (trial.require_movement) {
+      const enable_button = () => {
+        display_element.querySelector<HTMLInputElement>(
+          "#jspsych-canvas-slider-response-next"
+        ).disabled = false;
+      };
+
       display_element
-        .querySelector<HTMLElement>("#jspsych-canvas-slider-response-response")
-        .addEventListener("click", function () {
-          display_element.querySelector<HTMLButtonElement>(
-            "#jspsych-canvas-slider-response-next"
-          ).disabled = false;
-        });
+        .querySelector("#jspsych-canvas-slider-response-response")
+        .addEventListener("mousedown", enable_button);
+
+      display_element
+        .querySelector("#jspsych-canvas-slider-response-response")
+        .addEventListener("touchstart", enable_button);
     }
 
     display_element

--- a/packages/plugin-html-slider-response/src/index.ts
+++ b/packages/plugin-html-slider-response/src/index.ts
@@ -169,13 +169,19 @@ class HtmlSliderResponsePlugin implements JsPsychPlugin<Info> {
     };
 
     if (trial.require_movement) {
+      const enable_button = () => {
+        display_element.querySelector<HTMLInputElement>(
+          "#jspsych-html-slider-response-next"
+        ).disabled = false;
+      };
+
       display_element
         .querySelector("#jspsych-html-slider-response-response")
-        .addEventListener("click", function () {
-          display_element.querySelector<HTMLButtonElement>(
-            "#jspsych-html-slider-response-next"
-          ).disabled = false;
-        });
+        .addEventListener("mousedown", enable_button);
+
+      display_element
+        .querySelector("#jspsych-html-slider-response-response")
+        .addEventListener("touchstart", enable_button);
     }
 
     const end_trial = () => {

--- a/packages/plugin-image-slider-response/src/index.ts
+++ b/packages/plugin-image-slider-response/src/index.ts
@@ -352,13 +352,19 @@ class ImageSliderResponsePlugin implements JsPsychPlugin<Info> {
     };
 
     if (trial.require_movement) {
+      const enable_button = () => {
+        display_element.querySelector<HTMLInputElement>(
+          "#jspsych-image-slider-response-next"
+        ).disabled = false;
+      };
+
       display_element
         .querySelector("#jspsych-image-slider-response-response")
-        .addEventListener("click", function () {
-          display_element.querySelector<HTMLButtonElement>(
-            "#jspsych-image-slider-response-next"
-          ).disabled = false;
-        });
+        .addEventListener("mousedown", enable_button);
+
+      display_element
+        .querySelector("#jspsych-image-slider-response-response")
+        .addEventListener("touchstart", enable_button);
     }
 
     const end_trial = () => {

--- a/packages/plugin-video-slider-response/src/index.ts
+++ b/packages/plugin-video-slider-response/src/index.ts
@@ -303,13 +303,19 @@ class VideoSliderResponsePlugin implements JsPsychPlugin<Info> {
     }
 
     if (trial.require_movement) {
+      const enable_button = () => {
+        display_element.querySelector<HTMLInputElement>(
+          "#jspsych-video-slider-response-next"
+        ).disabled = false;
+      };
+
       display_element
         .querySelector("#jspsych-video-slider-response-response")
-        .addEventListener("click", function () {
-          display_element.querySelector<HTMLButtonElement>(
-            "#jspsych-video-slider-response-next"
-          ).disabled = false;
-        });
+        .addEventListener("mousedown", enable_button);
+
+      display_element
+        .querySelector("#jspsych-video-slider-response-response")
+        .addEventListener("touchstart", enable_button);
     }
 
     var startTime = performance.now();


### PR DESCRIPTION
Following the approach in #1773 this changes the event type that enables the response button in the *-slider-response plugins to `mousedown` or `touchstart`.
