### PR TITLE
2318 fix typo and broken link

### DIFF
--- a/docs/overview/timeline.md
+++ b/docs/overview/timeline.md
@@ -164,7 +164,7 @@ var face_name_procedure = {
 ### Using in a function
 
 Continung the example from the previous section, what if we wanted to show the name with the face, combining the two variables together? 
-To do this, we can use a [dynamic parameter](..overview/dynamic-parameters/) (a function) to create an HTML-string that uses both variables in a single parameter.
+To do this, we can use a [dynamic parameter](dynamic-parameters.md) (a function) to create an HTML-string that uses both variables in a single parameter.
 The value of the `stimulus` parameter will be a function that returns an HTML string that contains both the image and the name. 
 
 ```javascript

--- a/docs/overview/timeline.md
+++ b/docs/overview/timeline.md
@@ -229,7 +229,7 @@ The `type` parameter in this object controls the type of sampling that is done.
 Valid values for `type` are 
 
 * `"with-replacement"`: Sample `size` items from the timeline variables with the possibility of choosing the same item multiple time.
-* `"without-replacement"`: Sample `size` itesm from timeline variables, with each item being selected a maximum of 1 time.
+* `"without-replacement"`: Sample `size` items from timeline variables, with each item being selected a maximum of 1 time.
 * `"fixed-repetitons"`: Repeat each item in the timeline variables `size` times, in a random order. Unlike using the `repetitons` parameter, this method allows for consecutive trials to use the same timeline variable set.
 * `"alternate-groups"`: Sample in an alternating order based on a declared group membership. Groups are defined by the `groups` parameter. This parameter takes an array of arrays, where each inner array is a group and the items in the inner array are the indices of the timeline variables in the `timeline_variables` array that belong to that group.
 * `"custom"`: Write a function that returns a custom order of the timeline variables.

--- a/docs/overview/timeline.md
+++ b/docs/overview/timeline.md
@@ -164,7 +164,7 @@ var face_name_procedure = {
 ### Using in a function
 
 Continung the example from the previous section, what if we wanted to show the name with the face, combining the two variables together? 
-To do this, we can use a [dynamic parameter](dynamic-parameters) (a function) to create an HTML-string that uses both variables in a single parameter.
+To do this, we can use a [dynamic parameter](..overview/dynamic-parameters/) (a function) to create an HTML-string that uses both variables in a single parameter.
 The value of the `stimulus` parameter will be a function that returns an HTML string that contains both the image and the name. 
 
 ```javascript


### PR DESCRIPTION
This PR corrects the typo and links dynamic parameters to the correct url.

There's currently a typo in the docs on this page: https://www.jspsych.org/7.0/overview/timeline/
See screenshot:
<img width="714" alt="Screen Shot 2021-11-09 at 10 20 29 AM" src="https://user-images.githubusercontent.com/66799077/140952018-3984412a-529c-437f-a9e4-a520dc2b85cf.png">

Also, the link to the dynamic parameters page was sending me to a 404 page. 
<img width="936" alt="Screen Shot 2021-11-09 at 10 25 07 AM" src="https://user-images.githubusercontent.com/66799077/140952813-d54027b1-d15b-4bed-b98e-489d003aae76.png">
previous dynamic parameters link: https://www.jspsych.org/7.0/overview/timeline/dynamic-parameters
updated link: https://www.jspsych.org/7.0/overview/dynamic-parameters/

