### PR TITLE
Add a VERSION.md file to release archives

### DIFF
--- a/.changeset/nine-ties-shop.md
+++ b/.changeset/nine-ties-shop.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/config": minor
+---
+
+Add a VERSION.md file to the release archive created by the `createCoreDistArchive` Gulp task

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
                     owner,
                     repo,
                     release_id: releaseId,
-                    name: `${name.replace("@jspsych/", "jspsych-")}-${version}-dist.zip`,
+                    name: `jspsych.zip`,
                     label: "Dist archive (zip)",
                     headers: {
                       "content-type": "application/zip",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6928,6 +6928,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/gulp-file": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/gulp-file/-/gulp-file-0.4.0.tgz",
+      "integrity": "sha1-RRNWoqxQicbbkaBEQlKgVDZXAGs=",
+      "dependencies": {
+        "through2": "^0.4.1",
+        "vinyl": "^2.1.0"
+      }
+    },
+    "node_modules/gulp-file/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "node_modules/gulp-file/node_modules/object-keys": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+    },
+    "node_modules/gulp-file/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/gulp-file/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "node_modules/gulp-file/node_modules/through2": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+      "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
+      }
+    },
+    "node_modules/gulp-file/node_modules/xtend": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+      "dependencies": {
+        "object-keys": "~0.4.0"
+      },
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/gulp-rename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-2.0.0.tgz",
@@ -15498,6 +15553,7 @@
         "canvas": "2.8.0",
         "gulp": "4.0.2",
         "gulp-cli": "2.3.0",
+        "gulp-file": "^0.4.0",
         "gulp-rename": "2.0.0",
         "gulp-replace": "1.1.3",
         "gulp-zip": "5.1.0",
@@ -17920,6 +17976,7 @@
         "canvas": "2.8.0",
         "gulp": "4.0.2",
         "gulp-cli": "2.3.0",
+        "gulp-file": "^0.4.0",
         "gulp-rename": "2.0.0",
         "gulp-replace": "1.1.3",
         "gulp-zip": "5.1.0",
@@ -21755,6 +21812,60 @@
           "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
           "requires": {
             "ansi-wrap": "^0.1.0"
+          }
+        }
+      }
+    },
+    "gulp-file": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/gulp-file/-/gulp-file-0.4.0.tgz",
+      "integrity": "sha1-RRNWoqxQicbbkaBEQlKgVDZXAGs=",
+      "requires": {
+        "through2": "^0.4.1",
+        "vinyl": "^2.1.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+          "requires": {
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
+          }
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "requires": {
+            "object-keys": "~0.4.0"
           }
         }
       }

--- a/packages/config/gulp.js
+++ b/packages/config/gulp.js
@@ -1,12 +1,65 @@
+import { readFileSync } from "fs";
 import { sep as pathSeparator } from "path";
 
+import glob from "glob";
 import gulp from "gulp";
+import file from "gulp-file";
 import rename from "gulp-rename";
 import replace from "gulp-replace";
 import zip from "gulp-zip";
 import merge from "merge-stream";
 
 const { dest, src } = gulp;
+
+const readJsonFile = (filename) => JSON.parse(readFileSync(filename, "utf8"));
+
+const getVersionFileContents = () =>
+  [
+    "Included in this release:\n",
+    "Package|Version|Documentation",
+    "--- | --- | ---",
+    ...(() => {
+      const docsBaseUrl =
+        "https://www.jspsych.org/" +
+        readJsonFile("packages/jspsych/package.json").version.split(".").slice(0, -1).join(".") +
+        "/";
+
+      return (
+        glob
+          // Get an array of all package.json filenames
+          .sync("packages/*/package.json")
+
+          // Map file names to package details
+          .map((filename) => {
+            const packageJson = readJsonFile(filename);
+            return {
+              name: packageJson.name,
+              version: packageJson.version,
+            };
+          })
+
+          // Filter packages that should not be listed
+          .filter(({ name }) => !["@jspsych/config", "@jspsych/test-utils"].includes(name))
+
+          // Move the core package to the top of the list
+          .sort(({ name: n1 }, { name: n2 }) => (n1 === "jspsych" ? -1 : n2 === "jspsych" ? 1 : 0))
+
+          // Map package details to MarkDown table row strings
+          .map(({ name, version }) => {
+            return `${name.replace("@jspsych/", "")}|${version}|${
+              name === "jspsych"
+                ? docsBaseUrl
+                : name.startsWith("@jspsych/plugin-")
+                ? docsBaseUrl + "plugins/" + name.replace("@jspsych/plugin-", "")
+                : name.startsWith("@jspsych/extension-")
+                ? docsBaseUrl + "extensions/" + name.replace("@jspsych/extension-", "")
+                : ""
+            }`;
+          })
+      );
+    })(),
+    "",
+  ].join("\n");
 
 export const createCoreDistArchive = () =>
   merge(
@@ -43,6 +96,9 @@ export const createCoreDistArchive = () =>
           '<link rel="stylesheet" href="$1/dist/$2" />'
         )
       ),
+
+    // VERSION.md
+    file("VERSION.md", getVersionFileContents(), { src: true }),
 
     // Other files
     src(["*.md", "license.txt"])

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -56,6 +56,7 @@
     "canvas": "2.8.0",
     "gulp": "4.0.2",
     "gulp-cli": "2.3.0",
+    "gulp-file": "^0.4.0",
     "gulp-rename": "2.0.0",
     "gulp-replace": "1.1.3",
     "gulp-zip": "5.1.0",


### PR DESCRIPTION
As suggested by @jodeleeuw, this adds a VERSION.md file to release archives and at the same time uses `jspsych.zip` as the filename for all dist archives downloaded from GitHub.
