### PR TITLE
Misc. bug fixes for 7.1

### DIFF
--- a/.changeset/fast-bikes-clap.md
+++ b/.changeset/fast-bikes-clap.md
@@ -1,0 +1,7 @@
+---
+"@jspsych/plugin-video-button-response": patch
+"@jspsych/plugin-video-keyboard-response": patch
+"@jspsych/plugin-video-slider-response": patch
+---
+
+Fixes the `response_allowed_while_playing` parameter to use the `stop` time of the video as the event that enables a response.

--- a/.changeset/mean-bees-warn.md
+++ b/.changeset/mean-bees-warn.md
@@ -1,0 +1,9 @@
+---
+"@jspsych/plugin-audio-slider-response": patch
+"@jspsych/plugin-canvas-slider-response": patch
+"@jspsych/plugin-html-slider-response": patch
+"@jspsych/plugin-image-slider-response": patch
+"@jspsych/plugin-video-slider-response": patch
+---
+
+When `require_movement` is `true`, allow changes to the slider using the keyboard to enable the button (#1783).

--- a/.changeset/mighty-apricots-approve.md
+++ b/.changeset/mighty-apricots-approve.md
@@ -1,0 +1,7 @@
+---
+"@jspsych/plugin-video-button-response": patch
+"@jspsych/plugin-video-keyboard-response": patch
+"@jspsych/plugin-video-slider-response": patch
+---
+
+Throw an error when the `stimulus` parameter is not an array, see #1537 and #1530.

--- a/packages/plugin-audio-slider-response/src/index.ts
+++ b/packages/plugin-audio-slider-response/src/index.ts
@@ -248,6 +248,10 @@ class AudioSliderResponsePlugin implements JsPsychPlugin<Info> {
         display_element
           .querySelector("#jspsych-audio-slider-response-response")
           .addEventListener("touchstart", enable_button);
+
+        display_element
+          .querySelector("#jspsych-audio-slider-response-response")
+          .addEventListener("change", enable_button);
       }
 
       display_element

--- a/packages/plugin-canvas-slider-response/src/index.ts
+++ b/packages/plugin-canvas-slider-response/src/index.ts
@@ -206,6 +206,10 @@ class CanvasSliderResponsePlugin implements JsPsychPlugin<Info> {
       display_element
         .querySelector("#jspsych-canvas-slider-response-response")
         .addEventListener("touchstart", enable_button);
+
+      display_element
+        .querySelector("#jspsych-canvas-slider-response-response")
+        .addEventListener("change", enable_button);
     }
 
     display_element

--- a/packages/plugin-html-slider-response/src/index.ts
+++ b/packages/plugin-html-slider-response/src/index.ts
@@ -182,6 +182,10 @@ class HtmlSliderResponsePlugin implements JsPsychPlugin<Info> {
       display_element
         .querySelector("#jspsych-html-slider-response-response")
         .addEventListener("touchstart", enable_button);
+
+      display_element
+        .querySelector("#jspsych-html-slider-response-response")
+        .addEventListener("change", enable_button);
     }
 
     const end_trial = () => {

--- a/packages/plugin-image-slider-response/src/index.ts
+++ b/packages/plugin-image-slider-response/src/index.ts
@@ -365,6 +365,10 @@ class ImageSliderResponsePlugin implements JsPsychPlugin<Info> {
       display_element
         .querySelector("#jspsych-image-slider-response-response")
         .addEventListener("touchstart", enable_button);
+
+      display_element
+        .querySelector("#jspsych-image-slider-response-response")
+        .addEventListener("change", enable_button);
     }
 
     const end_trial = () => {

--- a/packages/plugin-video-button-response/src/index.spec.ts
+++ b/packages/plugin-video-button-response/src/index.spec.ts
@@ -9,6 +9,24 @@ beforeAll(() => {
   window.HTMLMediaElement.prototype.pause = () => {};
 });
 
+describe("video-button-response", () => {
+  test("throws error when stimulus is not array #1537", async () => {
+    const jsPsych = initJsPsych();
+
+    const timeline = [
+      {
+        type: videoButtonResponse,
+        stimulus: "foo.mp4",
+        choices: ["foo"],
+      },
+    ];
+
+    await expect(async () => {
+      await jsPsych.run(timeline);
+    }).rejects.toThrowError();
+  });
+});
+
 describe("video-button-response simulation", () => {
   test("data mode works", async () => {
     const timeline = [

--- a/packages/plugin-video-button-response/src/index.ts
+++ b/packages/plugin-video-button-response/src/index.ts
@@ -127,6 +127,13 @@ class VideoButtonResponsePlugin implements JsPsychPlugin<Info> {
   constructor(private jsPsych: JsPsych) {}
 
   trial(display_element: HTMLElement, trial: TrialType<Info>) {
+    if (!Array.isArray(trial.stimulus)) {
+      throw new Error(`
+        The stimulus property for the video-button-response plugin must be an array
+        of files. See https://www.jspsych.org/latest/plugins/video-button-response/#parameters
+      `);
+    }
+
     // setup stimulus
     var video_html = "<div>";
     video_html += '<video id="jspsych-video-button-response-stimulus"';

--- a/packages/plugin-video-button-response/src/index.ts
+++ b/packages/plugin-video-button-response/src/index.ts
@@ -268,6 +268,9 @@ class VideoButtonResponsePlugin implements JsPsychPlugin<Info> {
       video_element.addEventListener("timeupdate", (e) => {
         var currenttime = video_element.currentTime;
         if (currenttime >= trial.stop) {
+          if (!trial.response_allowed_while_playing) {
+            enable_buttons();
+          }
           video_element.pause();
           if (trial.trial_ends_after_video && !stopped) {
             // this is to prevent end_trial from being called twice, because the timeupdate event

--- a/packages/plugin-video-keyboard-response/src/index.spec.ts
+++ b/packages/plugin-video-keyboard-response/src/index.spec.ts
@@ -9,6 +9,24 @@ beforeAll(() => {
   window.HTMLMediaElement.prototype.pause = () => {};
 });
 
+// I can't figure out how to get this tested with jest
+describe("video-keyboard-response", () => {
+  test("throws error when stimulus is not array #1537", async () => {
+    const jsPsych = initJsPsych();
+
+    const timeline = [
+      {
+        type: videoKeyboardResponse,
+        stimulus: "foo.mp4",
+      },
+    ];
+
+    await expect(async () => {
+      await jsPsych.run(timeline);
+    }).rejects.toThrowError();
+  });
+});
+
 describe("video-keyboard-response simulation", () => {
   test("data mode works", async () => {
     const timeline = [

--- a/packages/plugin-video-keyboard-response/src/index.ts
+++ b/packages/plugin-video-keyboard-response/src/index.ts
@@ -107,6 +107,14 @@ class VideoKeyboardResponsePlugin implements JsPsychPlugin<Info> {
   constructor(private jsPsych: JsPsych) {}
 
   trial(display_element: HTMLElement, trial: TrialType<Info>) {
+    // catch mistake where stimuli are not an array
+    if (!Array.isArray(trial.stimulus)) {
+      throw new Error(`
+        The stimulus property for the video-keyboard-response plugin must be an array
+        of files. See https://www.jspsych.org/latest/plugins/video-keyboard-response/#parameters
+      `);
+    }
+
     // setup stimulus
     var video_html = "<div>";
     video_html += '<video id="jspsych-video-keyboard-response-stimulus"';

--- a/packages/plugin-video-keyboard-response/src/index.ts
+++ b/packages/plugin-video-keyboard-response/src/index.ts
@@ -222,6 +222,15 @@ class VideoKeyboardResponsePlugin implements JsPsychPlugin<Info> {
       video_element.addEventListener("timeupdate", (e) => {
         var currenttime = video_element.currentTime;
         if (currenttime >= trial.stop) {
+          if(!trial.response_allowed_while_playing) {
+            var keyboardListener = this.jsPsych.pluginAPI.getKeyboardResponse({
+              callback_function: after_response,
+              valid_responses: trial.choices,
+              rt_method: 'performance',
+              persist: false,
+              allow_held_key: false,
+            });
+          }
           video_element.pause();
           if (trial.trial_ends_after_video && !stopped) {
             // this is to prevent end_trial from being called twice, because the timeupdate event

--- a/packages/plugin-video-slider-response/src/index.spec.ts
+++ b/packages/plugin-video-slider-response/src/index.spec.ts
@@ -9,6 +9,23 @@ beforeAll(() => {
   window.HTMLMediaElement.prototype.pause = () => {};
 });
 
+describe("video-slider-response", () => {
+  test("throws error when stimulus is not array #1537", async () => {
+    const jsPsych = initJsPsych();
+
+    const timeline = [
+      {
+        type: videoSliderResponse,
+        stimulus: "foo.mp4",
+      },
+    ];
+
+    await expect(async () => {
+      await jsPsych.run(timeline);
+    }).rejects.toThrowError();
+  });
+});
+
 describe("video-slider-response simulation", () => {
   test("data mode works", async () => {
     const timeline = [

--- a/packages/plugin-video-slider-response/src/index.ts
+++ b/packages/plugin-video-slider-response/src/index.ts
@@ -147,7 +147,7 @@ type Info = typeof info;
 class VideoSliderResponsePlugin implements JsPsychPlugin<Info> {
   static info = info;
 
-  constructor(private jsPsych: JsPsych) { }
+  constructor(private jsPsych: JsPsych) {}
 
   trial(display_element: HTMLElement, trial: TrialType<Info>) {
     if (!Array.isArray(trial.stimulus)) {
@@ -299,11 +299,11 @@ class VideoSliderResponsePlugin implements JsPsychPlugin<Info> {
         } else {
           video_element.pause();
         }
-        video_element.onseeked = () => { };
+        video_element.onseeked = () => {};
       };
       video_element.onplaying = () => {
         video_element.currentTime = trial.start;
-        video_element.onplaying = () => { };
+        video_element.onplaying = () => {};
       };
       // fix for iOS/MacOS browsers: videos aren't seekable until they start playing, so need to hide/mute, play,
       // change current time, then show/unmute
@@ -324,7 +324,7 @@ class VideoSliderResponsePlugin implements JsPsychPlugin<Info> {
             end_trial();
           }
 
-          if (!trial.response_allowed_while_playing){
+          if (!trial.response_allowed_while_playing) {
             enable_slider();
           }
         }
@@ -345,6 +345,10 @@ class VideoSliderResponsePlugin implements JsPsychPlugin<Info> {
       display_element
         .querySelector("#jspsych-video-slider-response-response")
         .addEventListener("touchstart", enable_button);
+
+      display_element
+        .querySelector("#jspsych-video-slider-response-response")
+        .addEventListener("change", enable_button);
     }
 
     var startTime = performance.now();
@@ -367,7 +371,7 @@ class VideoSliderResponsePlugin implements JsPsychPlugin<Info> {
         .pause();
       display_element.querySelector<HTMLVideoElement>(
         "#jspsych-video-slider-response-stimulus-video"
-      ).onended = () => { };
+      ).onended = () => {};
 
       // gather the data to store for the trial
       var trial_data = {

--- a/packages/plugin-video-slider-response/src/index.ts
+++ b/packages/plugin-video-slider-response/src/index.ts
@@ -147,7 +147,7 @@ type Info = typeof info;
 class VideoSliderResponsePlugin implements JsPsychPlugin<Info> {
   static info = info;
 
-  constructor(private jsPsych: JsPsych) {}
+  constructor(private jsPsych: JsPsych) { }
 
   trial(display_element: HTMLElement, trial: TrialType<Info>) {
     if (!Array.isArray(trial.stimulus)) {
@@ -299,11 +299,11 @@ class VideoSliderResponsePlugin implements JsPsychPlugin<Info> {
         } else {
           video_element.pause();
         }
-        video_element.onseeked = () => {};
+        video_element.onseeked = () => { };
       };
       video_element.onplaying = () => {
         video_element.currentTime = trial.start;
-        video_element.onplaying = () => {};
+        video_element.onplaying = () => { };
       };
       // fix for iOS/MacOS browsers: videos aren't seekable until they start playing, so need to hide/mute, play,
       // change current time, then show/unmute
@@ -322,6 +322,10 @@ class VideoSliderResponsePlugin implements JsPsychPlugin<Info> {
             // can fire in quick succession
             stopped = true;
             end_trial();
+          }
+
+          if (!trial.response_allowed_while_playing){
+            enable_slider();
           }
         }
       });
@@ -363,7 +367,7 @@ class VideoSliderResponsePlugin implements JsPsychPlugin<Info> {
         .pause();
       display_element.querySelector<HTMLVideoElement>(
         "#jspsych-video-slider-response-stimulus-video"
-      ).onended = () => {};
+      ).onended = () => { };
 
       // gather the data to store for the trial
       var trial_data = {

--- a/packages/plugin-video-slider-response/src/index.ts
+++ b/packages/plugin-video-slider-response/src/index.ts
@@ -150,6 +150,13 @@ class VideoSliderResponsePlugin implements JsPsychPlugin<Info> {
   constructor(private jsPsych: JsPsych) {}
 
   trial(display_element: HTMLElement, trial: TrialType<Info>) {
+    if (!Array.isArray(trial.stimulus)) {
+      throw new Error(`
+        The stimulus property for the video-slider-response plugin must be an array
+        of files. See https://www.jspsych.org/latest/plugins/video-slider-response/#parameters
+      `);
+    }
+
     // half of the thumb width value from jspsych.css, used to adjust the label positions
     var half_thumb_width = 7.5;
 


### PR DESCRIPTION
This is a branch with misc. bug fixes for 7.1

- Adds error throw when video-* plugins `stimulus` parameter is not an array (#1530; #1537)
- Allow keyboard movements to enable slider when `require_movement` is true in slider plugins (#1783)
- Treat stop time in video plugins as the event that enables a response when `response_allowed_while_playing` is false. (#2259)