### PR TITLE
Patch: Fix simulation mode default option

### DIFF
--- a/.changeset/nine-onions-rhyme.md
+++ b/.changeset/nine-onions-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/test-utils": patch
+---
+
+Fix the default mode for `simulateTimeline()` to defer to jsPsych's default.

--- a/.changeset/popular-toes-marry.md
+++ b/.changeset/popular-toes-marry.md
@@ -1,0 +1,5 @@
+---
+"jspsych": patch
+---
+
+Fixed the default case for `jsPsych.simulate()` when no simulation_mode is specified. Now properly runs in data-only mode.

--- a/docs/demos/eye-tracking-with-webgazer.html
+++ b/docs/demos/eye-tracking-with-webgazer.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
@@ -13,7 +13,7 @@
     <script src="https://unpkg.com/@jspsych/extension-webgazer@1.0.0"></script>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css"
+      href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css"
     />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>

--- a/docs/demos/jspsych-animation-demo.html
+++ b/docs/demos/jspsych-animation-demo.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-animation@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <style>
       #jspsych-animation-image {
         height: 80% !important;

--- a/docs/demos/jspsych-audio-button-response-demo-1.html
+++ b/docs/demos/jspsych-audio-button-response-demo-1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-audio-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
   </head>
   <body></body>
   <script>

--- a/docs/demos/jspsych-audio-button-response-demo-2.html
+++ b/docs/demos/jspsych-audio-button-response-demo-2.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-audio-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
   </head>
   <body></body>
   <script>

--- a/docs/demos/jspsych-audio-keyboard-response-demo-1.html
+++ b/docs/demos/jspsych-audio-keyboard-response-demo-1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-audio-keyboard-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
   </head>
   <body></body>
   <script>

--- a/docs/demos/jspsych-audio-keyboard-response-demo-2.html
+++ b/docs/demos/jspsych-audio-keyboard-response-demo-2.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-audio-keyboard-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
   </head>
   <body></body>
   <script>

--- a/docs/demos/jspsych-audio-slider-response-demo-1.html
+++ b/docs/demos/jspsych-audio-slider-response-demo-1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-audio-slider-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
   </head>
   <body></body>
   <script>

--- a/docs/demos/jspsych-audio-slider-response-demo-2.html
+++ b/docs/demos/jspsych-audio-slider-response-demo-2.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-audio-slider-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
   </head>
   <body></body>
   <script>

--- a/docs/demos/jspsych-browser-check-demo1.html
+++ b/docs/demos/jspsych-browser-check-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-browser-check@1.0.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
   </head>
   <body></body>
   <script>

--- a/docs/demos/jspsych-browser-check-demo2.html
+++ b/docs/demos/jspsych-browser-check-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-browser-check@1.0.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
   </head>
   <body></body>
   <script>

--- a/docs/demos/jspsych-browser-check-demo3.html
+++ b/docs/demos/jspsych-browser-check-demo3.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-browser-check@1.0.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
   </head>
   <body></body>
   <script>

--- a/docs/demos/jspsych-browser-check-demo4.html
+++ b/docs/demos/jspsych-browser-check-demo4.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-browser-check@1.0.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
   </head>
   <body></body>
   <script>

--- a/docs/demos/jspsych-call-function-demo1.html
+++ b/docs/demos/jspsych-call-function-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-call-function@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css" />
   </head>
   <body></body>

--- a/docs/demos/jspsych-call-function-demo2.html
+++ b/docs/demos/jspsych-call-function-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-call-function@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css" />
   </head>
   <body></body>

--- a/docs/demos/jspsych-call-function-demo3.html
+++ b/docs/demos/jspsych-call-function-demo3.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-call-function@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css" />
   </head>
   <body></body>

--- a/docs/demos/jspsych-canvas-button-response-demo1.html
+++ b/docs/demos/jspsych-canvas-button-response-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-canvas-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css" />
   </head>
   <body></body>

--- a/docs/demos/jspsych-canvas-button-response-demo2.html
+++ b/docs/demos/jspsych-canvas-button-response-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-canvas-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css" />
   </head>
   <body></body>

--- a/docs/demos/jspsych-canvas-button-response-demo3.html
+++ b/docs/demos/jspsych-canvas-button-response-demo3.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-canvas-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css" />
   </head>
   <body></body>

--- a/docs/demos/jspsych-canvas-keyboard-response-demo1.html
+++ b/docs/demos/jspsych-canvas-keyboard-response-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-canvas-keyboard-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css" />
   </head>
   <body></body>

--- a/docs/demos/jspsych-canvas-keyboard-response-demo2.html
+++ b/docs/demos/jspsych-canvas-keyboard-response-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-canvas-keyboard-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css" />
   </head>
   <body></body>

--- a/docs/demos/jspsych-canvas-slider-response-demo1.html
+++ b/docs/demos/jspsych-canvas-slider-response-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-canvas-slider-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css" />
   </head>
   <body></body>

--- a/docs/demos/jspsych-canvas-slider-response-demo2.html
+++ b/docs/demos/jspsych-canvas-slider-response-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-canvas-slider-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css" />
   </head>
   <body></body>

--- a/docs/demos/jspsych-categorize-animation-demo1.html
+++ b/docs/demos/jspsych-categorize-animation-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-categorize-animation@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <style>
       #jspsych-categorize-animation-stimulus {
         height: 80% !important;

--- a/docs/demos/jspsych-categorize-animation-demo2.html
+++ b/docs/demos/jspsych-categorize-animation-demo2.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-categorize-animation@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <style>
       #jspsych-categorize-animation-stimulus {
         height: 80% !important;

--- a/docs/demos/jspsych-categorize-html-demo1.html
+++ b/docs/demos/jspsych-categorize-html-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-categorize-html@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-categorize-image-demo1.html
+++ b/docs/demos/jspsych-categorize-image-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-categorize-image@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-cloze-demo1.html
+++ b/docs/demos/jspsych-cloze-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-cloze@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-cloze-demo2.html
+++ b/docs/demos/jspsych-cloze-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-cloze@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-extension-mouse-tracking-demo1.html
+++ b/docs/demos/jspsych-extension-mouse-tracking-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <!--<script src="../../packages/extension-mouse-tracking/dist/index.browser.js"></script>-->
     <script src="https://unpkg.com/@jspsych/extension-mouse-tracking@1.0.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-external-html-demo1.html
+++ b/docs/demos/jspsych-external-html-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-external-html@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-free-sort-demo1.html
+++ b/docs/demos/jspsych-free-sort-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-free-sort@1.0.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-fullscreen-demo1.html
+++ b/docs/demos/jspsych-fullscreen-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-fullscreen@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <style>
       html,
       body {

--- a/docs/demos/jspsych-html-audio-response-demo1.html
+++ b/docs/demos/jspsych-html-audio-response-demo1.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <script src="https://unpkg.com/jspsych@7.1.0"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-audio-response@1.0.0"></script>
   <script src="https://unpkg.com/@jspsych/plugin-initialize-microphone@1.0.0"></script>
-  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css">
+  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css">
   <style>
     .jspsych-btn {margin-bottom: 10px;}
   </style>

--- a/docs/demos/jspsych-html-audio-response-demo2.html
+++ b/docs/demos/jspsych-html-audio-response-demo2.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <script src="https://unpkg.com/jspsych@7.1.0"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-audio-response@1.0.0"></script>
   <script src="https://unpkg.com/@jspsych/plugin-initialize-microphone@1.0.0"></script>
-  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css">
+  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css">
   <style>
     .jspsych-btn {margin-bottom: 10px;}
   </style>

--- a/docs/demos/jspsych-html-audio-response-demo3.html
+++ b/docs/demos/jspsych-html-audio-response-demo3.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <script src="https://unpkg.com/jspsych@7.1.0"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-audio-response@1.0.0"></script>
   <script src="https://unpkg.com/@jspsych/plugin-audio-button-response@1.1.0"></script>
   <script src="https://unpkg.com/@jspsych/plugin-initialize-microphone@1.0.0"></script>
-  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css">
+  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css">
   <style>
     .jspsych-btn {margin-bottom: 10px;}
   </style>

--- a/docs/demos/jspsych-html-button-response-demo1.html
+++ b/docs/demos/jspsych-html-button-response-demo1.html
@@ -2,9 +2,9 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-html-keyboard-response-demo1.html
+++ b/docs/demos/jspsych-html-keyboard-response-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-html-keyboard-response-demo2.html
+++ b/docs/demos/jspsych-html-keyboard-response-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-html-slider-response-demo1.html
+++ b/docs/demos/jspsych-html-slider-response-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-slider-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-iat-html-demo1.html
+++ b/docs/demos/jspsych-iat-html-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-iat-html@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-iat-image-demo1.html
+++ b/docs/demos/jspsych-iat-image-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-iat-image@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-image-button-response-demo1.html
+++ b/docs/demos/jspsych-image-button-response-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-image-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-image-keyboard-response-demo1.html
+++ b/docs/demos/jspsych-image-keyboard-response-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-image-keyboard-response-demo2.html
+++ b/docs/demos/jspsych-image-keyboard-response-demo2.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-image-slider-response-demo1.html
+++ b/docs/demos/jspsych-image-slider-response-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-image-slider-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-instructions-demo-1.html
+++ b/docs/demos/jspsych-instructions-demo-1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-instructions@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-instructions-demo-2.html
+++ b/docs/demos/jspsych-instructions-demo-2.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-instructions@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-instructions-demo-3.html
+++ b/docs/demos/jspsych-instructions-demo-3.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-instructions@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-maxdiff-demo1.html
+++ b/docs/demos/jspsych-maxdiff-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-maxdiff@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-preload-demo1.html
+++ b/docs/demos/jspsych-preload-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-image-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-preload-demo2.html
+++ b/docs/demos/jspsych-preload-demo2.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-image-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-preload-demo3.html
+++ b/docs/demos/jspsych-preload-demo3.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-image-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-preload-demo4.html
+++ b/docs/demos/jspsych-preload-demo4.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-image-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-reconstruction-demo1.html
+++ b/docs/demos/jspsych-reconstruction-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-reconstruction@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-resize-demo1.html
+++ b/docs/demos/jspsych-resize-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-resize@1.0.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-same-different-html-demo1.html
+++ b/docs/demos/jspsych-same-different-html-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-same-different-html@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-same-different-image-demo1.html
+++ b/docs/demos/jspsych-same-different-image-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-same-different-image@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-serial-reaction-time-demo1.html
+++ b/docs/demos/jspsych-serial-reaction-time-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-serial-reaction-time@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-serial-reaction-time-demo2.html
+++ b/docs/demos/jspsych-serial-reaction-time-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-serial-reaction-time@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-serial-reaction-time-mouse-demo1.html
+++ b/docs/demos/jspsych-serial-reaction-time-mouse-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-serial-reaction-time-mouse@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-serial-reaction-time-mouse-demo2.html
+++ b/docs/demos/jspsych-serial-reaction-time-mouse-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-serial-reaction-time-mouse@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-sketchpad-demo1.html
+++ b/docs/demos/jspsych-sketchpad-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-sketchpad@1.0.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-sketchpad-demo2.html
+++ b/docs/demos/jspsych-sketchpad-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-sketchpad@1.0.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-sketchpad-demo3.html
+++ b/docs/demos/jspsych-sketchpad-demo3.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-sketchpad@1.0.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey-text@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css" />
   </head>
   <body></body>

--- a/docs/demos/jspsych-survey-demo1.html
+++ b/docs/demos/jspsych-survey-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey@0.1.1"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="https://unpkg.com/@jspsych/plugin-survey@0.1.1/css/survey.css">
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>

--- a/docs/demos/jspsych-survey-demo2.html
+++ b/docs/demos/jspsych-survey-demo2.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey@0.1.1"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="https://unpkg.com/@jspsych/plugin-survey@0.1.1/css/survey.css">
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>

--- a/docs/demos/jspsych-survey-demo3.html
+++ b/docs/demos/jspsych-survey-demo3.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey@0.1.1"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="https://unpkg.com/@jspsych/plugin-survey@0.1.1/css/survey.css">
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>

--- a/docs/demos/jspsych-survey-demo4.html
+++ b/docs/demos/jspsych-survey-demo4.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey@0.1.1"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="https://unpkg.com/@jspsych/plugin-survey@0.1.1/css/survey.css">
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>

--- a/docs/demos/jspsych-survey-html-form-demo1.html
+++ b/docs/demos/jspsych-survey-html-form-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey-html-form@1.0.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-survey-html-form-demo2.html
+++ b/docs/demos/jspsych-survey-html-form-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey-html-form@1.0.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-survey-likert-demo1.html
+++ b/docs/demos/jspsych-survey-likert-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey-likert@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-survey-likert-demo2.html
+++ b/docs/demos/jspsych-survey-likert-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey-likert@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-survey-multi-choice-demo1.html
+++ b/docs/demos/jspsych-survey-multi-choice-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey-multi-choice@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-survey-multi-choice-demo2.html
+++ b/docs/demos/jspsych-survey-multi-choice-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey-multi-choice@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-survey-multi-select-demo1.html
+++ b/docs/demos/jspsych-survey-multi-select-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey-multi-select@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css" />
   </head>
   <body></body>

--- a/docs/demos/jspsych-survey-text-demo1.html
+++ b/docs/demos/jspsych-survey-text-demo1.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey-text@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-survey-text-demo2.html
+++ b/docs/demos/jspsych-survey-text-demo2.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey-text@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-survey-text-demo3.html
+++ b/docs/demos/jspsych-survey-text-demo3.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey-text@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-survey-text-demo4.html
+++ b/docs/demos/jspsych-survey-text-demo4.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-survey-text@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-video-button-response-demo1.html
+++ b/docs/demos/jspsych-video-button-response-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-video-button-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-video-keyboard-response-demo1.html
+++ b/docs/demos/jspsych-video-keyboard-response-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-video-keyboard-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-video-slider-response-demo1.html
+++ b/docs/demos/jspsych-video-slider-response-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-video-slider-response@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-virtual-chinrest-demo1.html
+++ b/docs/demos/jspsych-virtual-chinrest-demo1.html
@@ -2,12 +2,12 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-virtual-chinrest@1.0.0"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/2.6.3/svg.min"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-virtual-chinrest-demo2.html
+++ b/docs/demos/jspsych-virtual-chinrest-demo2.html
@@ -2,12 +2,12 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-virtual-chinrest@1.0.0"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/2.6.3/svg.min.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-virtual-chinrest-demo3.html
+++ b/docs/demos/jspsych-virtual-chinrest-demo3.html
@@ -2,12 +2,12 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-virtual-chinrest@1.0.0"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/2.6.3/svg.min.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-visual-search-circle-demo1.html
+++ b/docs/demos/jspsych-visual-search-circle-demo1.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-visual-search-circle@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/demos/jspsych-visual-search-circle-demo2.html
+++ b/docs/demos/jspsych-visual-search-circle-demo2.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <script src="docs-demo-timeline.js"></script>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-visual-search-circle@1.1.0"></script>
-    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" />
+    <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" />
     <link rel="stylesheet" href="docs-demo.css" type="text/css">
   </head>
   <body></body>

--- a/docs/overview/extensions.md
+++ b/docs/overview/extensions.md
@@ -8,7 +8,7 @@ To use an extension in an experiment, you'll load the extension file via a `<scr
 
 ```html
 <head>
-  <script src="https://unpkg.com/jspsych@7.1.0"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1"></script>
   <script src="https://unpkg.com/@jspsych/extension-example@1.0.0"></script>
 </head>
 ```

--- a/docs/overview/eye-tracking.md
+++ b/docs/overview/eye-tracking.md
@@ -10,7 +10,7 @@ The [official version of WebGazer](https://webgazer.cs.brown.edu/#download) is c
 
 You must include the `webgazer.js` file in your experiment via a `<script>` tag. 
 However, the `webgazer.js` file is not part of any of the jsPsych NPM packages and is therefore not available via the unpkg.com CDN. 
-Instead, it can be found on the jsdelivr.net CDN at: "https://cdn.jsdelivr.net/gh/jspsych/jspsych@7.1.1/examples/js/webgazer/webgazer.js".
+Instead, it can be found on the jsdelivr.net CDN at: "https://cdn.jsdelivr.net/gh/jspsych/jspsych@jspsych@7.1.1/examples/js/webgazer/webgazer.js".
 
 ```html
 <head>

--- a/docs/overview/eye-tracking.md
+++ b/docs/overview/eye-tracking.md
@@ -10,12 +10,12 @@ The [official version of WebGazer](https://webgazer.cs.brown.edu/#download) is c
 
 You must include the `webgazer.js` file in your experiment via a `<script>` tag. 
 However, the `webgazer.js` file is not part of any of the jsPsych NPM packages and is therefore not available via the unpkg.com CDN. 
-Instead, it can be found on the jsdelivr.net CDN at: "https://cdn.jsdelivr.net/gh/jspsych/jspsych@7.1.0/examples/js/webgazer/webgazer.js".
+Instead, it can be found on the jsdelivr.net CDN at: "https://cdn.jsdelivr.net/gh/jspsych/jspsych@7.1.1/examples/js/webgazer/webgazer.js".
 
 ```html
 <head>
-  <script src="https://unpkg.com/jspsych@7.1.0"></script>
-  <script src="https://cdn.jsdelivr.net/gh/jspsych/jspsych@7.1.0/examples/js/webgazer/webgazer.js"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jspsych/jspsych@7.1.1/examples/js/webgazer/webgazer.js"></script>
 </head>
 ```
 
@@ -33,8 +33,8 @@ The [webgazer extension](../extensions/webgazer.md) adds functionality to jsPsyc
 
 ```html
 <head>
-  <script src="https://unpkg.com/jspsych@7.1.0"></script>
-  <script src="https://cdn.jsdelivr.net/gh/jspsych/jspsych@7.1.0/examples/js/webgazer/webgazer.js"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1"></script>
+  <script src="https://cdn.jsdelivr.net/gh/jspsych/jspsych@7.1.1/examples/js/webgazer/webgazer.js"></script>
   <script src="https://unpkg.com/@jspsych/extension-webgazer@1.0.0"></script>
 </head>
 ```
@@ -167,7 +167,7 @@ If you have tips based on your own experience please consider sharing them on ou
     <!DOCTYPE html>
     <html>
       <head>
-        <script src="https://unpkg.com/jspsych@7.1.0"></script>
+        <script src="https://unpkg.com/jspsych@7.1.1"></script>
         <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-html-button-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
@@ -175,11 +175,11 @@ If you have tips based on your own experience please consider sharing them on ou
         <script src="https://unpkg.com/@jspsych/plugin-webgazer-init-camera@1.0.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-webgazer-calibrate@1.0.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-webgazer-validate@1.0.0"></script>
-        <script src="https://cdn.jsdelivr.net/gh/jspsych/jspsych@7.1.0/examples/js/webgazer/webgazer.js"></script>
+        <script src="https://cdn.jsdelivr.net/gh/jspsych/jspsych@7.1.1/examples/js/webgazer/webgazer.js"></script>
         <script src="https://unpkg.com/@jspsych/extension-webgazer@1.0.0"></script>
         <link
           rel="stylesheet"
-          href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css"
+          href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css"
         />
         <style>
           .jspsych-btn {

--- a/docs/overview/plugins.md
+++ b/docs/overview/plugins.md
@@ -13,7 +13,7 @@ To use a plugin, you'll need to load the plugin's JavaScript file in your experi
 
 ```html
 <head>
-  <script src="https://unpkg.com/jspsych@7.1.0" type="text/javascript"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1" type="text/javascript"></script>
   <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0" type="text/javascript"></script>
 </head>
 ```

--- a/docs/overview/style.md
+++ b/docs/overview/style.md
@@ -86,9 +86,9 @@ In the example below, the default font size is set to 25px throughout the experi
 
 ```html
 <head>
-  <script src="https://unpkg.com/jspsych@7.1.0"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
-  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css">
+  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css">
   <style> 
     .jspsych-display-element {
       font-size: 25px;
@@ -105,9 +105,9 @@ This example shows how to add a custom CSS file in addition to the styles provid
 
 ```html
 <head>
-  <script src="https://unpkg.com/jspsych@7.1.0"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1"></script>
   <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0"></script>
-  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css">
+  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css">
   <link rel="stylesheet" href="my_experiment_style.css">
 </head>
 ```
@@ -138,9 +138,9 @@ You can use a static `css_classes` parameter value if you always want to apply t
 
 ```html
  <head>
-  <script src="https://unpkg.com/jspsych@7.1.0"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
-  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css">
+  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css">
   <style> 
     .fixation {font-size: 90px; font-weight: bold; color: gray;}
   </style>
@@ -176,9 +176,9 @@ In the example below, the CSS selector `.left-align #stimulus` selects the eleme
 
 ```html
 <head>
-  <script src="https://unpkg.com/jspsych@7.1.0"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
-  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css">
+  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css">
   <style> 
     .left-align #stimulus {text-align: left; width: 600px;}
     .right-align #stimulus {text-align: right; width: 600px;}
@@ -206,9 +206,9 @@ It's also possible to pass multiple class names to the `css_classes` parameter. 
 
 ```html
 <head>
-  <script src="https://unpkg.com/jspsych@7.1.0"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
-  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css">
+  <link rel="stylesheet" href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css">
   <style> 
     .left-align #stimulus {text-align: left; width: 600px;}
     .right-align #stimulus {text-align: right; width: 600px;}

--- a/docs/tutorials/hello-world.md
+++ b/docs/tutorials/hello-world.md
@@ -45,7 +45,7 @@ To use jsPsych, add a `<script>` tag to load the library. We'll load the library
 <html>
   <head>
     <title>My experiment</title>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
   </head>
   <body></body>
 </html>
@@ -60,8 +60,8 @@ You may also want to import the jsPsych stylesheet, which applies a basic set of
 <html>
   <head>
     <title>My experiment</title>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
-    <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
+    <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
   </head>
   <body></body>
 </html>
@@ -76,8 +76,8 @@ To add JavaScript code directly to the webpage we need to add a pair of `<script
 <html>
   <head>
     <title>My experiment</title>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
-    <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
+    <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
   </head>
   <body></body>
   <script>
@@ -92,8 +92,8 @@ To initialize jsPsych we use the `initJsPsych()` function and assign the output 
 <html>
   <head>
     <title>My experiment</title>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
-    <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
+    <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
   </head>
   <body></body>
   <script>
@@ -111,9 +111,9 @@ For this demo we want to show some text on the screen. This is exactly what the 
 <html>
   <head>
     <title>My experiment</title>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
-    <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+    <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
   </head>
   <body></body>
   <script>
@@ -129,9 +129,9 @@ Once the plugin is loaded we can create a trial using the plugin. To declare a t
 <html>
   <head>
     <title>My experiment</title>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
-    <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+    <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
   </head>
   <body></body>
   <script>
@@ -154,9 +154,9 @@ Now that we have the trial defined we need to tell jsPsych to run an experiment 
 <html>
   <head>
     <title>My experiment</title>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
-    <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+    <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
   </head>
   <body></body>
   <script>

--- a/docs/tutorials/rt-task.md
+++ b/docs/tutorials/rt-task.md
@@ -25,9 +25,9 @@ Start by setting up a new HTML file with jsPsych, the html-keyboard-response plu
 <html>
   <head>
     <title>My experiment</title>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
-    <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+    <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
   </head>
   <body></body>
   <script>
@@ -87,9 +87,9 @@ After each step in the tutorial you can view the complete code up to that point 
     <html>
       <head>
         <title>My experiment</title>
-        <script src="https://unpkg.com/jspsych@7.1.0"></script>
+        <script src="https://unpkg.com/jspsych@7.1.1"></script>
         <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
-        <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+        <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
       </head>
       <body></body>
       <script>
@@ -166,9 +166,9 @@ timeline.push(instructions);
     <html>
       <head>
         <title>My experiment</title>
-        <script src="https://unpkg.com/jspsych@7.1.0"></script>
+        <script src="https://unpkg.com/jspsych@7.1.1"></script>
         <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
-        <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+        <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
       </head>
       <body></body>
       <script>
@@ -223,10 +223,10 @@ We need to start by loading this plugin by adding a `<script>` tag to the docume
 ```html hl_lines="5"
 <head>
   <title>My experiment</title>
-  <script src="https://unpkg.com/jspsych@7.1.0"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
   <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0"></script>
-  <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+  <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
 </head>
 ```
 
@@ -261,10 +261,10 @@ timeline.push(blue_trial, orange_trial);
     <html>
       <head>
         <title>My experiment</title>
-        <script src="https://unpkg.com/jspsych@7.1.0"></script>
+        <script src="https://unpkg.com/jspsych@7.1.1"></script>
         <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0"></script>
-        <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+        <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
       </head>
       <body></body>
       <script>
@@ -339,11 +339,11 @@ First we need to add the preload plugin to our `<head>` section.
 ```html hl_lines="6"
 <head>
   <title>My experiment</title>
-  <script src="https://unpkg.com/jspsych@7.1.0"></script>
+  <script src="https://unpkg.com/jspsych@7.1.1"></script>
   <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
   <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0"></script>
   <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-  <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+  <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
 </head>
 ```
 
@@ -370,11 +370,11 @@ timeline.push(preload);
     <html>
       <head>
         <title>My experiment</title>
-        <script src="https://unpkg.com/jspsych@7.1.0"></script>
+        <script src="https://unpkg.com/jspsych@7.1.1"></script>
         <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-        <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+        <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
       </head>
       <body></body>
       <script>
@@ -503,11 +503,11 @@ What happens when the experiment reaches the test procedure? jsPsych will run th
     <html>
       <head>
         <title>My experiment</title>
-        <script src="https://unpkg.com/jspsych@7.1.0"></script>
+        <script src="https://unpkg.com/jspsych@7.1.1"></script>
         <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-        <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+        <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
       </head>
       <body></body>
       <script>
@@ -617,11 +617,11 @@ var test_procedure = {
     <html>
       <head>
         <title>My experiment</title>
-        <script src="https://unpkg.com/jspsych@7.1.0"></script>
+        <script src="https://unpkg.com/jspsych@7.1.1"></script>
         <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-        <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+        <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
       </head>
       <body></body>
       <script>
@@ -838,11 +838,11 @@ var jsPsych = initJsPsych({
     <html>
       <head>
         <title>My experiment</title>
-        <script src="https://unpkg.com/jspsych@7.1.0"></script>
+        <script src="https://unpkg.com/jspsych@7.1.1"></script>
         <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-        <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+        <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
       </head>
       <body></body>
       <script>
@@ -995,11 +995,11 @@ var fixation = {
     <html>
       <head>
         <title>My experiment</title>
-        <script src="https://unpkg.com/jspsych@7.1.0"></script>
+        <script src="https://unpkg.com/jspsych@7.1.1"></script>
         <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-        <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+        <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
       </head>
       <body></body>
       <script>
@@ -1134,11 +1134,11 @@ The `data.response` value is a string representation of the key the subject pres
     <html>
       <head>
         <title>My experiment</title>
-        <script src="https://unpkg.com/jspsych@7.1.0"></script>
+        <script src="https://unpkg.com/jspsych@7.1.1"></script>
         <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0"></script>
         <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-        <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+        <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
       </head>
       <body></body>
       <script>
@@ -1284,11 +1284,11 @@ This code is available in the `/examples` folder in the jsPsych release download
 <html>
   <head>
     <title>My experiment</title>
-    <script src="https://unpkg.com/jspsych@7.1.0"></script>
+    <script src="https://unpkg.com/jspsych@7.1.1"></script>
     <script src="https://unpkg.com/@jspsych/plugin-html-keyboard-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-image-keyboard-response@1.1.0"></script>
     <script src="https://unpkg.com/@jspsych/plugin-preload@1.1.0"></script>
-    <link href="https://unpkg.com/jspsych@7.1.0/css/jspsych.css" rel="stylesheet" type="text/css" />
+    <link href="https://unpkg.com/jspsych@7.1.1/css/jspsych.css" rel="stylesheet" type="text/css" />
   </head>
   <body></body>
   <script>

--- a/packages/jspsych/src/JsPsych.ts
+++ b/packages/jspsych/src/JsPsych.ts
@@ -189,7 +189,7 @@ export class JsPsych {
 
   async simulate(
     timeline: any[],
-    simulation_mode: "data-only" | "visual",
+    simulation_mode: "data-only" | "visual" = "data-only",
     simulation_options = {}
   ) {
     this.simulation_mode = simulation_mode;

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -144,7 +144,7 @@ export async function startTimeline(timeline: any[], jsPsych: JsPsych | any = {}
  */
 export async function simulateTimeline(
   timeline: any[],
-  simulation_mode: "data-only" | "visual" = "data-only",
+  simulation_mode?: "data-only" | "visual",
   simulation_options: any = {},
   jsPsych: JsPsych | any = {}
 ) {


### PR DESCRIPTION
This fixes the default option when `jsPsych.simulate()` is run with no simulation mode selected. In 7.1 this results in the experiment executing in non-simulation mode because the default option is `undefined` and the experiment defaults to running the actual trial mode. This bug happened because the `simulateExperiment()` test util had a default mode implemented in it. I remove the default from `simulateExperiment` and updated `simulate()` to use a default of `data-only`.

I also bumped all the docs use of `jsPsych@7.1.0` to `jsPsych@7.1.1`