### PR TITLE
Add `filterColumns`, the opposite of `ignore()`.

### DIFF
--- a/.changeset/happy-shirts-drum.md
+++ b/.changeset/happy-shirts-drum.md
@@ -1,0 +1,5 @@
+---
+"jspsych": minor
+---
+
+Added `filterColumns()` to the DataCollection class. This function lets users select a subset of the columns in the DataCollection. It is the opposite of the `ignore()` method.

--- a/docs/reference/jspsych-data.md
+++ b/docs/reference/jspsych-data.md
@@ -364,6 +364,15 @@ The filter method returns a DataCollection object, so methods can be chained ont
 var block_1_correct = jsPsych.data.get().filter({block:1, correct:true}).count();
 ```
 
+#### .filterColumns()
+
+Selects the set of columns listed in the array. This is the opposite of the `.ignore()` method.
+
+```javascript
+// Get only the subject, rt, and condition entries for each trial.
+const subset_of_data = jsPsych.data.get().filterColumns(['subject', 'rt', 'condition'])
+```
+
 #### .filterCustom()
 
 This method is similar to the `.filter()` method, except that it accepts a function as the filter. The function is passed a single argument, containing the data for a trial. If the function returns `true` the trial is included in the returned DataCollection.

--- a/packages/jspsych/src/modules/data/DataCollection.ts
+++ b/packages/jspsych/src/modules/data/DataCollection.ts
@@ -142,6 +142,7 @@ export class DataCollection {
       );
       filtered_data.push(filtered_columns);
     }
+    return new DataCollection(filtered_data);
   }
 
   select(column) {

--- a/packages/jspsych/src/modules/data/DataCollection.ts
+++ b/packages/jspsych/src/modules/data/DataCollection.ts
@@ -134,6 +134,16 @@ export class DataCollection {
     return new DataCollection(this.trials.filter(fn));
   }
 
+  filterColumns(columns: Array<string>) {
+    const filtered_data = [];
+    for (const trial of this.trials) {
+      const filtered_columns = Object.fromEntries(
+        columns.filter((key) => key in trial).map((key) => [key, trial[key]])
+      );
+      filtered_data.push(filtered_columns);
+    }
+  }
+
   select(column) {
     const values = [];
     for (const trial of this.trials) {

--- a/packages/jspsych/tests/data/datacollection.test.ts
+++ b/packages/jspsych/tests/data/datacollection.test.ts
@@ -15,14 +15,14 @@ describe("DataCollection", () => {
     dataCollection = new DataCollection(data);
   });
 
-  test("#filter", () => {
+  test("filter", () => {
     expect(dataCollection.filter({ filter: true }).count()).toBe(2);
   });
-  test("#filter OR", () => {
+  test("filter OR", () => {
     expect(dataCollection.filter([{ filter: true }, { rt: 300 }]).count()).toBe(2);
     expect(dataCollection.filter([{ filter: true }, { rt: 200 }]).count()).toBe(3);
   });
-  test("#filterCustom", () => {
+  test("filterCustom", () => {
     expect(
       dataCollection
         .filterCustom((x) => {
@@ -31,43 +31,43 @@ describe("DataCollection", () => {
         .count()
     ).toBe(2);
   });
-  test("#ignore", () => {
+  test("ignore", () => {
     expect(dataCollection.ignore("rt").select("rt").count()).toBe(0);
   });
-  test("#select", () => {
+  test("select", () => {
     expect(JSON.stringify(dataCollection.select("rt").values)).toBe(
       JSON.stringify([100, 200, 300, 400, 500])
     );
   });
-  test("#addToAll", () => {
+  test("addToAll", () => {
     expect(dataCollection.readOnly().addToAll({ added: 5 }).select("added").count()).toBe(5);
   });
-  test("#addToLast", () => {
+  test("addToLast", () => {
     dataCollection.addToLast({ lastonly: true });
     expect(dataCollection.values()[4].lastonly).toBe(true);
   });
-  test("#readOnly", () => {
+  test("readOnly", () => {
     const d = dataCollection.readOnly().values();
     d[0].rt = 0;
     expect(dataCollection.values()[0].rt).toBe(100);
   });
-  test("not #readOnly", () => {
+  test("not readOnly", () => {
     const d = dataCollection.values();
     d[0].rt = 0;
     expect(dataCollection.values()[0].rt).toBe(0);
   });
-  test("#count", () => {
+  test("count", () => {
     expect(dataCollection.count()).toBe(5);
   });
-  test("#push", () => {
+  test("push", () => {
     dataCollection.push({ rt: 600, filter: true });
     expect(dataCollection.count()).toBe(6);
   });
-  test("#values", () => {
+  test("values", () => {
     expect(JSON.stringify(dataCollection.values())).toBe(JSON.stringify(data));
     expect(dataCollection.values()).toBe(data);
   });
-  test("#first", () => {
+  test("first", () => {
     expect(dataCollection.first(3).count()).toBe(3);
     expect(dataCollection.first(2).values()[1].rt).toBe(200);
     expect(dataCollection.first().count()).toBe(1);
@@ -82,7 +82,7 @@ describe("DataCollection", () => {
     const too_many = n + 1;
     expect(dataCollection.first(too_many).count()).toBe(n);
   });
-  test("#last", () => {
+  test("last", () => {
     expect(dataCollection.last(2).count()).toBe(2);
     expect(dataCollection.last(2).values()[0].rt).toBe(400);
     expect(dataCollection.last().count()).toBe(1);
@@ -97,14 +97,14 @@ describe("DataCollection", () => {
     const too_many = n + 1;
     expect(dataCollection.last(too_many).count()).toBe(n);
   });
-  test("#join", () => {
+  test("join", () => {
     const dc1 = dataCollection.filter({ filter: true });
     const dc2 = dataCollection.filter({ rt: 500 });
     const data = dc1.join(dc2);
     expect(data.count()).toBe(3);
     expect(data.values()[2].rt).toBe(500);
   });
-  test("#unqiueNames", () => {
+  test("unqiueNames", () => {
     expect(
       new DataCollection([
         { rt: 100, filter: true },

--- a/packages/jspsych/tests/data/datacollection.test.ts
+++ b/packages/jspsych/tests/data/datacollection.test.ts
@@ -31,6 +31,26 @@ describe("DataCollection", () => {
         .count()
     ).toBe(2);
   });
+
+  test("filterColumns", () => {
+    data = [
+      { foo: "bar", rt: 100, filter: true },
+      { foo: "bar", rt: 200, filter: false },
+      { foo: "bar", rt: 300, filter: true },
+      { foo: "bar", rt: 400, filter: false },
+      { foo: "bar", rt: 500, filter: false },
+    ];
+    dataCollection = new DataCollection(data);
+
+    const filtered_data = dataCollection.filterColumns(["rt", "foo"]);
+
+    expect(
+      filtered_data.values().filter((x) => {
+        return x.foo && x.rt && !x.filter;
+      }).length
+    ).toBe(5);
+  });
+
   test("ignore", () => {
     expect(dataCollection.ignore("rt").select("rt").count()).toBe(0);
   });


### PR DESCRIPTION
This adds a `filterColumns()` method to the DataCollection class. It can be used to select a subset of the entries for all trials. 

```javascript
// Get only the subject, rt, and condition entries for each trial.
const subset_of_data = jsPsych.data.get().filterColumns(['subject', 'rt', 'condition'])
```

Based on discussion in #1613, but implemented for v7.

Closes #699.
