### PR TITLE
Add `updateUnpkgLinks` Gulp task

### DIFF
--- a/.changeset/sweet-cheetahs-grin.md
+++ b/.changeset/sweet-cheetahs-grin.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/config": minor
+---
+
+Implement an `updateUnpkgLinks` Gulp task to update each unpkg link with a precise version number to the corresponding package's current version as defined in the package's `package.json`.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,1 +1,1 @@
-export { createCoreDistArchive } from "@jspsych/config/gulp";
+export { createCoreDistArchive, updateUnpkgLinks } from "@jspsych/config/gulp";

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:watch": "npm test -- --watch",
     "build": "npm run build -w jspsych && npm run build -ws",
     "build:archive": "gulp createCoreDistArchive",
+    "update-unpkg-links": "gulp updateUnpkgLinks",
     "prepare": "husky install && npm run build",
     "tsc": "npm run tsc -ws",
     "changeset": "changeset",


### PR DESCRIPTION
In accordance with #2348, this adds an `updateUnpkgLinks` Gulp task that can be run via `npm run update-unpkg-links`. For now, we'll have to run it manually and commit the results to the `changeset-release/main` branch directly before each release.