### PR TITLE
Fix an error in browser-check doc 

### DIFF
--- a/docs/plugins/browser-check.md
+++ b/docs/plugins/browser-check.md
@@ -96,7 +96,7 @@ As with all simulated plugins, you can override the default (actual) data with f
         var trial = {
           type: jsPsychBrowserCheck,
           inclusion_function: (data) => {
-            return ['chrome', 'firefox'].contains(data.browser);
+            return ['chrome', 'firefox'].includes(data.browser);
           },
           exclusion_message: `<p>You must use Chrome or Firefox to complete this experiment.</p>`
         };


### PR DESCRIPTION
The contains method does not exist for arrays, which led to an error in one if the browser-check's example. 

I replaced `contains` with `includes` and it should now work! 