### PR TITLE
Fix css path rewriting in `createCoreDistArchive` Gulp task

### DIFF
--- a/.changeset/yellow-ducks-poke.md
+++ b/.changeset/yellow-ducks-poke.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/config": patch
+---
+
+Fix css path rewriting in `createCoreDistArchive` Gulp task when `link` tags do not end in `/>`

--- a/packages/config/gulp.js
+++ b/packages/config/gulp.js
@@ -85,15 +85,15 @@ export const createCoreDistArchive = () =>
       // Rewrite script source paths
       .pipe(
         replace(
-          /<script src="(.*)\/packages\/(.*)\/dist\/index\.browser\.js"><\/script>/g,
-          '<script src="$1/dist/$2.js"></script>'
+          /<script src="(.*)\/packages\/(.*)\/dist\/index\.browser\.js"/g,
+          '<script src="$1/dist/$2.js"'
         )
       )
       // Rewrite jspsych css source paths
       .pipe(
         replace(
-          /<link rel="stylesheet" href="(.*)\/packages\/jspsych\/css\/(.*)" \/>/g,
-          '<link rel="stylesheet" href="$1/dist/$2" />'
+          /<link rel="stylesheet" href="(.*)\/packages\/jspsych\/css\/(.*)"/g,
+          '<link rel="stylesheet" href="$1/dist/$2"'
         )
       ),
 


### PR DESCRIPTION
Turns out only `link`s ending in ` />` were replaced previously.

Closes #2496﻿
