### PR TITLE
Make `data-only` simulation mode skip any `post_trial_gap` (fix for #2497)

### DIFF
--- a/.changeset/poor-ways-cheer.md
+++ b/.changeset/poor-ways-cheer.md
@@ -1,0 +1,5 @@
+---
+"jspsych": patch
+---
+
+Fixed an issue where the `post_trial_gap` was still run in realtime during `data-only` simulation mode. The gap is now skipped as intended.

--- a/packages/jspsych/src/JsPsych.ts
+++ b/packages/jspsych/src/JsPsych.ts
@@ -302,7 +302,9 @@ export class JsPsych {
     this.internal.call_immediate = false;
 
     // wait for iti
-    if (
+    if (this.simulation_mode === "data-only") {
+      this.nextTrial();
+    } else if (
       typeof current_trial.post_trial_gap === null ||
       typeof current_trial.post_trial_gap === "undefined"
     ) {

--- a/packages/jspsych/tests/core/simulation-mode.test.ts
+++ b/packages/jspsych/tests/core/simulation-mode.test.ts
@@ -394,4 +394,24 @@ describe("data simulation mode", () => {
 
     await expectFinished();
   });
+
+  test("Simulation in data-only mode skips post_trial_gap", async () => {
+    const timeline = [
+      {
+        type: htmlKeyboardResponse,
+        stimulus: "foo",
+        post_trial_gap: 1000,
+      },
+      {
+        type: htmlKeyboardResponse,
+        stimulus: "foo",
+      },
+    ];
+
+    const { expectFinished, getData } = await simulateTimeline(timeline);
+
+    await expectFinished();
+
+    expect(getData().values().length).toBe(2);
+  });
 });


### PR DESCRIPTION
fixes #2497 