### PR TITLE
Remove `crypto` module dependency

### DIFF
--- a/.changeset/eighty-flowers-cry.md
+++ b/.changeset/eighty-flowers-cry.md
@@ -1,0 +1,5 @@
+---
+"jspsych": patch
+---
+
+Fix a ReferenceError ("`require$$0` is not defined") related to the new seedable random number generator

--- a/package-lock.json
+++ b/package-lock.json
@@ -2901,11 +2901,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/seedrandom": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/semver": {
       "version": "6.2.3",
       "dev": true,
@@ -12548,7 +12543,8 @@
     },
     "node_modules/seedrandom": {
       "version": "3.0.5",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "node_modules/semver": {
       "version": "5.7.1",
@@ -15462,7 +15458,6 @@
         "@fontsource/open-sans": "4.5.3",
         "@jspsych/config": "^1.2.0",
         "@types/dom-mediacapture-record": "^1.0.11",
-        "@types/seedrandom": "^3.0.1",
         "base64-inline-loader": "^2.0.1",
         "css-loader": "^6.6.0",
         "mini-css-extract-plugin": "^2.5.3",
@@ -18267,10 +18262,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/seedrandom": {
-      "version": "3.0.2",
-      "dev": true
     },
     "@types/semver": {
       "version": "6.2.3",
@@ -22610,7 +22601,6 @@
         "@fontsource/open-sans": "4.5.3",
         "@jspsych/config": "^1.2.0",
         "@types/dom-mediacapture-record": "^1.0.11",
-        "@types/seedrandom": "^3.0.1",
         "auto-bind": "^4.0.0",
         "base64-inline-loader": "^2.0.1",
         "css-loader": "^6.6.0",
@@ -24530,7 +24520,9 @@
       }
     },
     "seedrandom": {
-      "version": "3.0.5"
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "semver": {
       "version": "5.7.1"

--- a/packages/jspsych/package.json
+++ b/packages/jspsych/package.json
@@ -49,7 +49,6 @@
     "@fontsource/open-sans": "4.5.3",
     "@jspsych/config": "^1.2.0",
     "@types/dom-mediacapture-record": "^1.0.11",
-    "@types/seedrandom": "^3.0.1",
     "base64-inline-loader": "^2.0.1",
     "css-loader": "^6.6.0",
     "mini-css-extract-plugin": "^2.5.3",

--- a/packages/jspsych/src/modules/randomization.ts
+++ b/packages/jspsych/src/modules/randomization.ts
@@ -7,7 +7,7 @@ import seedrandom from "seedrandom/lib/alea";
  * @param seed An optional seed. If none is given, a random seed will be generated.
  * @returns The seed value.
  */
-export function setSeed(seed: string = seedrandom().int32().toString()) {
+export function setSeed(seed: string = Math.random().toString()) {
   Math.random = seedrandom(seed);
   return seed;
 }

--- a/packages/jspsych/src/modules/randomization.ts
+++ b/packages/jspsych/src/modules/randomization.ts
@@ -1,5 +1,5 @@
 import rw from "random-words";
-import seedrandom from "seedrandom";
+import seedrandom from "seedrandom/lib/alea";
 
 /**
  * Uses the `seedrandom` package to replace Math.random() with a seedable PRNG.
@@ -7,12 +7,8 @@ import seedrandom from "seedrandom";
  * @param seed An optional seed. If none is given, a random seed will be generated.
  * @returns The seed value.
  */
-export function setSeed(seed?: string) {
-  if (!seed) {
-    const prng = seedrandom();
-    seed = prng.int32().toString();
-  }
-  seedrandom(seed, { global: true });
+export function setSeed(seed: string = seedrandom().int32().toString()) {
+  Math.random = seedrandom(seed);
   return seed;
 }
 


### PR DESCRIPTION
Since we cannot get rid of [this](https://github.com/davidbau/seedrandom/blob/4460ad325a0a15273a211e509f03ae0beb99511a/seedrandom.js#L236) in `seedrandom/seedrandom`, I have included [another PRNG](https://github.com/davidbau/seedrandom#other-fast-prng-algorithms) (`seedrandom/lib/alea`, due to its performance and small size) that doesn't mention `crypto`. No breaking change, since v7.2.0 doesn't work anyway :see_no_evil: