### PR TITLE
Added `input_type` parameter to plugin-survey

### DIFF
--- a/.changeset/old-dogs-sniff.md
+++ b/.changeset/old-dogs-sniff.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/plugin-survey": minor
+---
+
+Added input_type parameter

--- a/.changeset/old-dogs-sniff.md
+++ b/.changeset/old-dogs-sniff.md
@@ -2,4 +2,4 @@
 "@jspsych/plugin-survey": minor
 ---
 
-Added input_type parameter
+Add `input_type` parameter for questions of type `text`

--- a/docs/plugins/survey.md
+++ b/docs/plugins/survey.md
@@ -173,7 +173,7 @@ placeholder | string | "" | Placeholder text in the text response field.
 textbox_rows | integer | 1 | The number of rows (height) for the response text box. 
 textbox_columns | integer | 40 | The number of columns (width) for the response text box. 
 validation | string | "" | A regular expression used to validate the response.
-input_type | string | "text" | Type for the HTML `<input>` element. The `input_type` parameter must be one of "color", "date", "datetime-local", "email", "month", "number", "password", "range", "tel", "text", "time", "url", "week". If the `textbox_rows` parameter is larger than 1, the `input_type` parameter will be ignored. For some types, such as date and time, the `textbox_columns` parameter will be ignored because the width is automatically determined. Note: SurveyJS supports the "datetime" type, but since this is deprecated, we will not support it in this plugin.
+input_type | string | "text" | Type for the HTML `<input>` element. The `input_type` parameter must be one of "color", "date", "datetime-local", "email", "month", "number", "password", "range", "tel", "text", "time", "url", "week". If the `textbox_rows` parameter is larger than 1, the `input_type` parameter will be ignored. The `textbox_columns` parameter only affects questions with `input_type` "email", "password", "tel", "url", or "text".
 
 ## Data Generated
 

--- a/docs/plugins/survey.md
+++ b/docs/plugins/survey.md
@@ -173,6 +173,7 @@ placeholder | string | "" | Placeholder text in the text response field.
 textbox_rows | integer | 1 | The number of rows (height) for the response text box. 
 textbox_columns | integer | 40 | The number of columns (width) for the response text box. 
 validation | string | "" | A regular expression used to validate the response.
+input_type | string | "text" | Type for the HTML `<input>` element. The `input_type` parameter must be one of "color", "date", "datetime-local", "email", "month", "number", "password", "range", "tel", "text", "time", "url", "week". If the `textbox_rows` parameter is larger than 1, the `input_type` parameter will be ignored. For some types, such as date and time, the `textbox_columns` parameter will be ignored because the width is automatically determined. Note: SurveyJS supports the "datetime" type, but since this is deprecated, we will not support it in this plugin.
 
 ## Data Generated
 

--- a/packages/plugin-survey/example.html
+++ b/packages/plugin-survey/example.html
@@ -25,13 +25,13 @@
           {type: 'html', prompt: '<p>Here is some arbitrary text via an "html" question type.<br>Similar to preamble but can be inserted anywhere in the question set.</p><p>This trial uses automatic question numbering (continued across pages).</p>'},
           {type: 'text', prompt: 'This is a single-line text question. The correct answer is "hello".', required: true, correct_response: "hello"},
           {type: 'text', prompt: 'This is a multi-line text question.', placeholder: 'This is a placeholder.', textbox_rows: 10, textbox_columns: 40},
-          {type: 'text', prompt: 'This is a single-line text question that only numbers can be entered.', input_type: 'number'},
-          {type: 'text', prompt: 'This is a date question', input_type: 'date'},
+          {type: 'text', prompt: 'This is a single-line text question of input_type "number"', input_type: 'number'},
+          {type: 'text', prompt: 'This is a single-line text question of input_type "date"', input_type: 'date'},
         ],
         [
           {
-            type: 'likert', 
-            prompt: 'This is a likert question prompt.', 
+            type: 'likert',
+            prompt: 'This is a likert question prompt.',
             likert_scale_values: [
               {value: 1},
               {value: 2},

--- a/packages/plugin-survey/example.html
+++ b/packages/plugin-survey/example.html
@@ -25,6 +25,8 @@
           {type: 'html', prompt: '<p>Here is some arbitrary text via an "html" question type.<br>Similar to preamble but can be inserted anywhere in the question set.</p><p>This trial uses automatic question numbering (continued across pages).</p>'},
           {type: 'text', prompt: 'This is a single-line text question. The correct answer is "hello".', required: true, correct_response: "hello"},
           {type: 'text', prompt: 'This is a multi-line text question.', placeholder: 'This is a placeholder.', textbox_rows: 10, textbox_columns: 40},
+          {type: 'text', prompt: 'This is a single-line text question that only numbers can be entered.', input_type: 'number'},
+          {type: 'text', prompt: 'This is a date question', input_type: 'date'},
         ],
         [
           {

--- a/packages/plugin-survey/src/index.spec.ts
+++ b/packages/plugin-survey/src/index.spec.ts
@@ -225,5 +225,60 @@ describe("survey plugin", () => {
     await expectFinished();
   });
 
+  test("loads single-line text questions of various input types", async () => {
+    const inputTypes = [
+      "color",
+      "date",
+      // "datetime",
+      "datetime-local",
+      "email",
+      "month",
+      "number",
+      "password",
+      "range",
+      "tel",
+      "text",
+      "time",
+      "url",
+      "week",
+    ];
+
+    for (const inputType of inputTypes) {
+      const { displayElement, expectFinished, getData } = await startTimeline([
+        {
+          type: survey,
+          pages: [
+            [
+              {
+                type: "text",
+                prompt: "foo",
+                input_type: inputType,
+              },
+            ],
+          ],
+        },
+      ]);
+
+      const question = displayElement.querySelector('div[name="P0_Q0"]');
+      expect(question).not.toBeNull();
+      expect(question.querySelector("span").innerHTML).toBe("foo");
+
+      const textinput = displayElement.querySelectorAll("input");
+
+      expect(textinput[0]).not.toBeNull();
+      expect(textinput[0].type).toBe(inputType);
+      if (["text", "search", "tel", "url", "email", "password"].includes(inputType)) {
+        // size can be specified only for text input types
+        expect(textinput[0].size).toBe(40);
+      }
+
+      const finish_button = displayElement.querySelector("input.sv_complete_btn");
+      expect(finish_button).not.toBeNull();
+      clickTarget(finish_button);
+
+      await expectFinished();
+    }
+  });
+
   // survey options
 });

--- a/packages/plugin-survey/src/index.spec.ts
+++ b/packages/plugin-survey/src/index.spec.ts
@@ -229,7 +229,6 @@ describe("survey plugin", () => {
     const inputTypes = [
       "color",
       "date",
-      // "datetime",
       "datetime-local",
       "email",
       "month",
@@ -253,6 +252,7 @@ describe("survey plugin", () => {
                 type: "text",
                 prompt: "foo",
                 input_type: inputType,
+                textbox_columns: 10,
               },
             ],
           ],
@@ -263,13 +263,14 @@ describe("survey plugin", () => {
       expect(question).not.toBeNull();
       expect(question.querySelector("span").innerHTML).toBe("foo");
 
-      const textinput = displayElement.querySelectorAll("input");
-
-      expect(textinput[0]).not.toBeNull();
-      expect(textinput[0].type).toBe(inputType);
-      if (["text", "search", "tel", "url", "email", "password"].includes(inputType)) {
+      const input = displayElement.querySelectorAll("input")[0];
+      expect(input).not.toBeNull();
+      expect(input.type).toEqual(inputType);
+      if (["email", "password", "tel", "url", "text"].includes(inputType)) {
         // size can be specified only for text input types
-        expect(textinput[0].size).toBe(40);
+        expect(input.size).toEqual(10);
+      } else {
+        expect(input.size).not.toEqual(10);
       }
 
       const finish_button = displayElement.querySelector("input.sv_complete_btn");

--- a/packages/plugin-survey/src/index.ts
+++ b/packages/plugin-survey/src/index.ts
@@ -195,6 +195,36 @@ const info = <const>{
           default: 40,
         },
         /**
+         * Text only: Type for the HTML <input> element.
+         * The `input_type` parameter must be one of "color", "date", "datetime-local", "email", "month", "number", "password", "range", "tel", "text", "time", "url", "week".
+         * If the `textbox_rows` parameter is larger than 1, the `input_type` parameter will be ignored.
+         * For some types, such as date and time, the `textbox_columns` parameter will be ignored because the width is automatically determined.
+         *
+         * Note: SurveyJS supports the "datetime" type, but since this is deprecated, we will not support it in this plugin.
+         * @see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime
+         */
+        input_type: {
+          type: ParameterType.SELECT,
+          pretty_name: "Input type",
+          default: "text",
+          options: [
+            "color",
+            "date",
+            // "datetime",
+            "datetime-local",
+            "email",
+            "month",
+            "number",
+            "password",
+            "range",
+            "tel",
+            "text",
+            "time",
+            "url",
+            "week",
+          ],
+        },
+        /**
          * All question types except HTML: value of the correct response. If specified, the response will be compared to this value,
          * and an additional data property "correct" will store response accuracy (true or false).
          */
@@ -320,6 +350,7 @@ const text_params = [
   "placeholder",
   "textbox_rows",
   "textbox_columns",
+  "input_type",
   "correct_response",
 ];
 
@@ -738,7 +769,7 @@ class SurveyPlugin implements JsPsychPlugin<Info> {
     SurveyPlugin.validate_question_params(
       params,
       [],
-      ["placeholder", "textbox_rows", "textbox_columns", "correct_response"]
+      ["placeholder", "textbox_rows", "textbox_columns", "input_type", "correct_response"]
     );
 
     SurveyPlugin.set_question_defaults(params, text_params);
@@ -754,8 +785,12 @@ class SurveyPlugin implements JsPsychPlugin<Info> {
     if (question instanceof QuestionComment) {
       question.rows = params.textbox_rows;
       question.cols = params.textbox_columns;
-    } else {
+    } else if (question.isTextInput) {
       question.size = params.textbox_columns;
+      question.inputType = params.input_type;
+    } else {
+      // size parameter is not set because QuestionText will update it automatically
+      question.inputType = params.input_type;
     }
     question.defaultValue = "";
 

--- a/packages/plugin-survey/src/index.ts
+++ b/packages/plugin-survey/src/index.ts
@@ -198,10 +198,7 @@ const info = <const>{
          * Text only: Type for the HTML <input> element.
          * The `input_type` parameter must be one of "color", "date", "datetime-local", "email", "month", "number", "password", "range", "tel", "text", "time", "url", "week".
          * If the `textbox_rows` parameter is larger than 1, the `input_type` parameter will be ignored.
-         * For some types, such as date and time, the `textbox_columns` parameter will be ignored because the width is automatically determined.
-         *
-         * Note: SurveyJS supports the "datetime" type, but since this is deprecated, we will not support it in this plugin.
-         * @see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime
+         * The `textbox_columns` parameter only affects questions with `input_type` "email", "password", "tel", "url", or "text".
          */
         input_type: {
           type: ParameterType.SELECT,
@@ -210,7 +207,6 @@ const info = <const>{
           options: [
             "color",
             "date",
-            // "datetime",
             "datetime-local",
             "email",
             "month",
@@ -785,11 +781,8 @@ class SurveyPlugin implements JsPsychPlugin<Info> {
     if (question instanceof QuestionComment) {
       question.rows = params.textbox_rows;
       question.cols = params.textbox_columns;
-    } else if (question.isTextInput) {
-      question.size = params.textbox_columns;
-      question.inputType = params.input_type;
     } else {
-      // size parameter is not set because QuestionText will update it automatically
+      question.size = params.textbox_columns;
       question.inputType = params.input_type;
     }
     question.defaultValue = "";


### PR DESCRIPTION
Hi jsPsych team,
I have modified the survey plugin to allow the `inputType` to be specified as a parameter.
This PR should also solve https://github.com/jspsych/jsPsych/issues/2597 .
Thanks in advance for your review!