### PR TITLE
Export css files of plugin-survey

### DIFF
--- a/.changeset/spicy-lies-sell.md
+++ b/.changeset/spicy-lies-sell.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/plugin-survey": patch
+---
+
+Export css files of plugin-survey

--- a/.changeset/spicy-lies-sell.md
+++ b/.changeset/spicy-lies-sell.md
@@ -2,4 +2,4 @@
 "@jspsych/plugin-survey": patch
 ---
 
-Export css files of plugin-survey
+Export css files in `package.json`

--- a/docs/plugins/survey.md
+++ b/docs/plugins/survey.md
@@ -27,6 +27,11 @@ This plugin uses an additional stylesheet called `survey.css`. You can load it v
 <link rel="stylesheet" href="https://unpkg.com/@jspsych/plugin-survey@0.1.1/css/survey.css">
 ```
 
+If you are using a bundler such as [webpack](https://webpack.js.org/), you can also import it in JavaScript as follows, depending on your bundler configuration:
+```javascript
+import '@jspsych/plugin-survey/css/survey.css'
+```
+
 ## Parameters
 
 In addition to the [parameters available in all plugins](../overview/plugins.md#parameters-available-in-all-plugins), this plugin accepts the following parameters. 

--- a/packages/plugin-survey/package.json
+++ b/packages/plugin-survey/package.json
@@ -5,8 +5,11 @@
   "type": "module",
   "main": "dist/index.cjs",
   "exports": {
-    "import": "./dist/index.js",
-    "require": "./dist/index.cjs"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./css/*": "./css/*"
   },
   "typings": "dist/index.d.ts",
   "unpkg": "dist/index.browser.min.js",

--- a/packages/plugin-survey/package.json
+++ b/packages/plugin-survey/package.json
@@ -9,7 +9,8 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
-    "./css/*": "./css/*"
+    "./css/survey.css": "./css/survey.css",
+    "./css/survey.scss": "./css/survey.scss"
   },
   "typings": "dist/index.d.ts",
   "unpkg": "dist/index.browser.min.js",


### PR DESCRIPTION
I have made it possible to load the survey plugin's stylesheet in JavaScript using a bundler such as webpack.
The `exports` in `package.json` is the same as in the jspsych package:
https://github.com/jspsych/jsPsych/blob/main/packages/jspsych/package.json#L7-L13
I have verified that this change works correctly in my local environment, but if there are any tests I should add, please let me know.