### PR TITLE
Updated rollup-plugin-typescript2 to work with latest version of node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3149,6 +3149,84 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "node_modules/@yarn-tool/resolve-package": {
+      "version": "1.0.47",
+      "resolved": "https://registry.npmjs.org/@yarn-tool/resolve-package/-/resolve-package-1.0.47.tgz",
+      "integrity": "sha512-Zaw58gQxjQceJqhqybJi1oUDaORT8i2GTgwICPs8v/X/Pkx35FXQba69ldHVg5pQZ6YLKpROXgyHvBaCJOFXiA==",
+      "dependencies": {
+        "pkg-dir": "< 6 >= 5",
+        "tslib": "^2",
+        "upath2": "^3.1.13"
+      }
+    },
+    "node_modules/@yarn-tool/resolve-package/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@yarn-tool/resolve-package/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@yarn-tool/resolve-package/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@yarn-tool/resolve-package/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@yarn-tool/resolve-package/node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/abab": {
       "version": "2.0.5",
       "license": "BSD-3-Clause"
@@ -9503,6 +9581,7 @@
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -11456,6 +11535,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-is-network-drive": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/path-is-network-drive/-/path-is-network-drive-1.0.15.tgz",
+      "integrity": "sha512-bJGs1SxUne+q29P1xCLMkNBhMetku+vPN+yVQu8FGL/7diHesCSSIKoF4Wq42tcbwm7rK72XrGfK8FUXN00LLQ==",
+      "dependencies": {
+        "tslib": "^2"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "license": "MIT",
@@ -11482,6 +11569,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-strip-sep": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/path-strip-sep/-/path-strip-sep-1.0.12.tgz",
+      "integrity": "sha512-EJZSC5WBjVlA9XHLCiluiyisYg6yzeMJ4nY3BQVCuedyEHA/I2crcHWdwuQ74h3V599U9nEbEZUTvvSxOK3vbQ==",
+      "dependencies": {
+        "tslib": "^2"
       }
     },
     "node_modules/path-type": {
@@ -12372,14 +12467,16 @@
       }
     },
     "node_modules/rollup-plugin-typescript2": {
-      "version": "0.30.0",
-      "license": "MIT",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.31.2.tgz",
+      "integrity": "sha512-hRwEYR1C8xDGVVMFJQdEVnNAeWRvpaY97g5mp3IeLnzhNXzSVq78Ye/BJ9PAaUfN4DXa/uDnqerifMOaMFY54Q==",
       "dependencies": {
-        "@rollup/pluginutils": "^4.1.0",
-        "find-cache-dir": "^3.3.1",
-        "fs-extra": "8.1.0",
-        "resolve": "1.20.0",
-        "tslib": "2.1.0"
+        "@rollup/pluginutils": "^4.1.2",
+        "@yarn-tool/resolve-package": "^1.0.40",
+        "find-cache-dir": "^3.3.2",
+        "fs-extra": "^10.0.0",
+        "resolve": "^1.20.0",
+        "tslib": "^2.3.1"
       },
       "peerDependencies": {
         "rollup": ">=1.26.3",
@@ -12387,8 +12484,9 @@
       }
     },
     "node_modules/rollup-plugin-typescript2/node_modules/@rollup/pluginutils": {
-      "version": "4.1.1",
-      "license": "MIT",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
       "dependencies": {
         "estree-walker": "^2.0.1",
         "picomatch": "^2.2.2"
@@ -12399,23 +12497,40 @@
     },
     "node_modules/rollup-plugin-typescript2/node_modules/estree-walker": {
       "version": "2.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/rollup-plugin-typescript2/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "license": "MIT",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=12"
       }
     },
-    "node_modules/rollup-plugin-typescript2/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
+    "node_modules/rollup-plugin-typescript2/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/rollup-plugin-typescript2/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -14515,6 +14630,17 @@
         "yarn": "*"
       }
     },
+    "node_modules/upath2": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/upath2/-/upath2-3.1.13.tgz",
+      "integrity": "sha512-M88uBoqgzrkXvXrF/+oSIPsTmL21uRwGhPVJKODrl+3lXkQ5NPKrTYuSBZVa+lgPGFoI6qYyHlSKACFHO0AoNw==",
+      "dependencies": {
+        "@types/node": "*",
+        "path-is-network-drive": "^1.0.15",
+        "path-strip-sep": "^1.0.12",
+        "tslib": "^2"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -15467,7 +15593,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -15503,7 +15628,7 @@
         "merge-stream": "2.0.0",
         "rollup": "2.58.0",
         "rollup-plugin-terser": "7.0.2",
-        "rollup-plugin-typescript2": "0.30.0",
+        "rollup-plugin-typescript2": "0.31.2",
         "ts-jest": "27.0.5",
         "tslib": "2.3.1",
         "typescript": "4.4.3"
@@ -17678,7 +17803,7 @@
         "merge-stream": "2.0.0",
         "rollup": "2.58.0",
         "rollup-plugin-terser": "7.0.2",
-        "rollup-plugin-typescript2": "0.30.0",
+        "rollup-plugin-typescript2": "0.31.2",
         "ts-jest": "27.0.5",
         "tslib": "2.3.1",
         "typescript": "4.4.3"
@@ -18636,6 +18761,59 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
+    },
+    "@yarn-tool/resolve-package": {
+      "version": "1.0.47",
+      "resolved": "https://registry.npmjs.org/@yarn-tool/resolve-package/-/resolve-package-1.0.47.tgz",
+      "integrity": "sha512-Zaw58gQxjQceJqhqybJi1oUDaORT8i2GTgwICPs8v/X/Pkx35FXQba69ldHVg5pQZ6YLKpROXgyHvBaCJOFXiA==",
+      "requires": {
+        "pkg-dir": "< 6 >= 5",
+        "tslib": "^2",
+        "upath2": "^3.1.13"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        }
+      }
     },
     "abab": {
       "version": "2.0.5"
@@ -22735,6 +22913,7 @@
     },
     "jsonfile": {
       "version": "4.0.0",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -24003,6 +24182,14 @@
     "path-is-absolute": {
       "version": "1.0.1"
     },
+    "path-is-network-drive": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/path-is-network-drive/-/path-is-network-drive-1.0.15.tgz",
+      "integrity": "sha512-bJGs1SxUne+q29P1xCLMkNBhMetku+vPN+yVQu8FGL/7diHesCSSIKoF4Wq42tcbwm7rK72XrGfK8FUXN00LLQ==",
+      "requires": {
+        "tslib": "^2"
+      }
+    },
     "path-key": {
       "version": "3.1.1"
     },
@@ -24017,6 +24204,14 @@
     },
     "path-root-regex": {
       "version": "0.1.2"
+    },
+    "path-strip-sep": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/path-strip-sep/-/path-strip-sep-1.0.12.tgz",
+      "integrity": "sha512-EJZSC5WBjVlA9XHLCiluiyisYg6yzeMJ4nY3BQVCuedyEHA/I2crcHWdwuQ74h3V599U9nEbEZUTvvSxOK3vbQ==",
+      "requires": {
+        "tslib": "^2"
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -24573,35 +24768,55 @@
       }
     },
     "rollup-plugin-typescript2": {
-      "version": "0.30.0",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.31.2.tgz",
+      "integrity": "sha512-hRwEYR1C8xDGVVMFJQdEVnNAeWRvpaY97g5mp3IeLnzhNXzSVq78Ye/BJ9PAaUfN4DXa/uDnqerifMOaMFY54Q==",
       "requires": {
-        "@rollup/pluginutils": "^4.1.0",
-        "find-cache-dir": "^3.3.1",
-        "fs-extra": "8.1.0",
-        "resolve": "1.20.0",
-        "tslib": "2.1.0"
+        "@rollup/pluginutils": "^4.1.2",
+        "@yarn-tool/resolve-package": "^1.0.40",
+        "find-cache-dir": "^3.3.2",
+        "fs-extra": "^10.0.0",
+        "resolve": "^1.20.0",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
         "@rollup/pluginutils": {
-          "version": "4.1.1",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+          "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
           "requires": {
             "estree-walker": "^2.0.1",
             "picomatch": "^2.2.2"
           }
         },
         "estree-walker": {
-          "version": "2.0.2"
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
         },
         "fs-extra": {
-          "version": "8.1.0",
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
           "requires": {
             "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
         },
-        "tslib": {
-          "version": "2.1.0"
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
         }
       }
     },
@@ -25936,6 +26151,17 @@
     "upath": {
       "version": "1.2.0"
     },
+    "upath2": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/upath2/-/upath2-3.1.13.tgz",
+      "integrity": "sha512-M88uBoqgzrkXvXrF/+oSIPsTmL21uRwGhPVJKODrl+3lXkQ5NPKrTYuSBZVa+lgPGFoI6qYyHlSKACFHO0AoNw==",
+      "requires": {
+        "@types/node": "*",
+        "path-is-network-drive": "^1.0.15",
+        "path-strip-sep": "^1.0.12",
+        "tslib": "^2"
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -26588,8 +26814,7 @@
       }
     },
     "yocto-queue": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.0"
     }
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -61,7 +61,7 @@
     "merge-stream": "2.0.0",
     "rollup": "2.58.0",
     "rollup-plugin-terser": "7.0.2",
-    "rollup-plugin-typescript2": "0.30.0",
+    "rollup-plugin-typescript2": "0.31.2",
     "ts-jest": "27.0.5",
     "tslib": "2.3.1",
     "typescript": "4.4.3"


### PR DESCRIPTION
Before this change, `npm run build` failed to work on node v18.1.0 on Arch Linux with this error

```
npm run build

> build
> turbo run build

• Packages in scope: @jspsych/config, @jspsych/extension-mouse-tracking, @jspsych/extension-webgazer, @jspsych/plugin-animation, @jspsych/plugin-audio-button-response, @jspsych/plugin-audio-keyboard-response, @jspsych/plugin-audio-slider-response, @jspsych/plugin-browser-check, @jspsych/plugin-call-function, @jspsych/plugin-canvas-button-response, @jspsych/plugin-canvas-keyboard-response, @jspsych/plugin-canvas-slider-response, @jspsych/plugin-categorize-animation, @jspsych/plugin-categorize-html, @jspsych/plugin-categorize-image, @jspsych/plugin-cloze, @jspsych/plugin-external-html, @jspsych/plugin-free-sort, @jspsych/plugin-fullscreen, @jspsych/plugin-html-audio-response, @jspsych/plugin-html-button-response, @jspsych/plugin-html-keyboard-response, @jspsych/plugin-html-slider-response, @jspsych/plugin-iat-html, @jspsych/plugin-iat-image, @jspsych/plugin-image-button-response, @jspsych/plugin-image-keyboard-response, @jspsych/plugin-image-slider-response, @jspsych/plugin-initialize-microphone, @jspsych/plugin-instructions, @jspsych/plugin-maxdiff, @jspsych/plugin-preload, @jspsych/plugin-reconstruction, @jspsych/plugin-resize, @jspsych/plugin-same-different-html, @jspsych/plugin-same-different-image, @jspsych/plugin-serial-reaction-time, @jspsych/plugin-serial-reaction-time-mouse, @jspsych/plugin-sketchpad, @jspsych/plugin-survey, @jspsych/plugin-survey-html-form, @jspsych/plugin-survey-likert, @jspsych/plugin-survey-multi-choice, @jspsych/plugin-survey-multi-select, @jspsych/plugin-survey-text, @jspsych/plugin-video-button-response, @jspsych/plugin-video-keyboard-response, @jspsych/plugin-video-slider-response, @jspsych/plugin-virtual-chinrest, @jspsych/plugin-visual-search-circle, @jspsych/plugin-webgazer-calibrate, @jspsych/plugin-webgazer-init-camera, @jspsych/plugin-webgazer-validate, @jspsych/test-utils, jspsych
• Running build in 55 packages
jspsych:build: cache miss, executing ef394ddc3a7a363f
jspsych:build:
jspsych:build: > jspsych@7.2.1 build
jspsych:build: > run-p build:js build:styles
jspsych:build:
jspsych:build:
jspsych:build: > jspsych@7.2.1 build:js
jspsych:build: > rollup --config
jspsych:build:
jspsych:build:
jspsych:build: > jspsych@7.2.1 build:styles
jspsych:build: > webpack-cli
jspsych:build:
jspsych:build: Error loading `tslib` helper library.
jspsych:build: [!] Error: Package subpath './package.json' is not defined by "exports" in /home/vijaymarupudi/Documents/test/jsPsych/node_modules/rollup-plugin-typescript2/node_modules/tslib/package.json
jspsych:build: Error: Package subpath './package.json' is not defined by "exports" in /home/vijaymarupudi/Documents/test/jsPsych/node_modules/rollup-plugin-typescript2/node_modules/tslib/package.json
jspsych:build:     at new NodeError (node:internal/errors:377:5)
jspsych:build:     at throwExportsNotFound (node:internal/modules/esm/resolve:440:9)
jspsych:build:     at packageExportsResolve (node:internal/modules/esm/resolve:719:3)
jspsych:build:     at resolveExports (node:internal/modules/cjs/loader:483:36)
jspsych:build:     at Function.Module._findPath (node:internal/modules/cjs/loader:523:31)
jspsych:build:     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:925:27)
jspsych:build:     at Function.Module._load (node:internal/modules/cjs/loader:780:27)
jspsych:build:     at Module.require (node:internal/modules/cjs/loader:1005:19)
jspsych:build:     at require (node:internal/modules/cjs/helpers:102:18)
jspsych:build:     at Object.<anonymous> (/home/vijaymarupudi/Documents/test/jsPsych/node_modules/rollup-plugin-typescript2/src/tslib.ts:11:23)
jspsych:build:
jspsych:build: npm ERR! Lifecycle script `build:js` failed with error:
jspsych:build: npm ERR! Error: command failed
jspsych:build: npm ERR!   in workspace: jspsych@7.2.1
jspsych:build: npm ERR!   at location: /home/vijaymarupudi/Documents/test/jsPsych/packages/jspsych
jspsych:build: ERROR: "build:js" exited with 1.
jspsych:build: npm ERR! Lifecycle script `build` failed with error:
jspsych:build: npm ERR! Error: command failed
jspsych:build: npm ERR!   in workspace: jspsych@7.2.1
jspsych:build: npm ERR!   at location: /home/vijaymarupudi/Documents/test/jsPsych/packages/jspsych
jspsych:build: Error: command finished with error: command
(packages/jspsych) npm run build exited (1)
```