### PR TITLE
Fix `@rollup/plugin-babel` config in conjunction with `rollup-plugin-typescript2`

### DIFF
--- a/.changeset/six-cycles-wait.md
+++ b/.changeset/six-cycles-wait.md
@@ -1,0 +1,57 @@
+---
+"@jspsych/extension-mouse-tracking": patch
+"@jspsych/extension-webgazer": patch
+"jspsych": patch
+"@jspsych/plugin-animation": patch
+"@jspsych/plugin-audio-button-response": patch
+"@jspsych/plugin-audio-keyboard-response": patch
+"@jspsych/plugin-audio-slider-response": patch
+"@jspsych/plugin-browser-check": patch
+"@jspsych/plugin-call-function": patch
+"@jspsych/plugin-canvas-button-response": patch
+"@jspsych/plugin-canvas-keyboard-response": patch
+"@jspsych/plugin-canvas-slider-response": patch
+"@jspsych/plugin-categorize-animation": patch
+"@jspsych/plugin-categorize-html": patch
+"@jspsych/plugin-categorize-image": patch
+"@jspsych/plugin-cloze": patch
+"@jspsych/plugin-external-html": patch
+"@jspsych/plugin-free-sort": patch
+"@jspsych/plugin-fullscreen": patch
+"@jspsych/plugin-html-audio-response": patch
+"@jspsych/plugin-html-button-response": patch
+"@jspsych/plugin-html-keyboard-response": patch
+"@jspsych/plugin-html-slider-response": patch
+"@jspsych/plugin-iat-html": patch
+"@jspsych/plugin-iat-image": patch
+"@jspsych/plugin-image-button-response": patch
+"@jspsych/plugin-image-keyboard-response": patch
+"@jspsych/plugin-image-slider-response": patch
+"@jspsych/plugin-initialize-microphone": patch
+"@jspsych/plugin-instructions": patch
+"@jspsych/plugin-maxdiff": patch
+"@jspsych/plugin-preload": patch
+"@jspsych/plugin-reconstruction": patch
+"@jspsych/plugin-resize": patch
+"@jspsych/plugin-same-different-html": patch
+"@jspsych/plugin-same-different-image": patch
+"@jspsych/plugin-serial-reaction-time": patch
+"@jspsych/plugin-serial-reaction-time-mouse": patch
+"@jspsych/plugin-sketchpad": patch
+"@jspsych/plugin-survey": patch
+"@jspsych/plugin-survey-html-form": patch
+"@jspsych/plugin-survey-likert": patch
+"@jspsych/plugin-survey-multi-choice": patch
+"@jspsych/plugin-survey-multi-select": patch
+"@jspsych/plugin-survey-text": patch
+"@jspsych/plugin-video-button-response": patch
+"@jspsych/plugin-video-keyboard-response": patch
+"@jspsych/plugin-video-slider-response": patch
+"@jspsych/plugin-virtual-chinrest": patch
+"@jspsych/plugin-visual-search-circle": patch
+"@jspsych/plugin-webgazer-calibrate": patch
+"@jspsych/plugin-webgazer-init-camera": patch
+"@jspsych/plugin-webgazer-validate": patch
+---
+
+Improve browser compatibility when loading via `unpkg.com`, i.e. when using the `dist/index.browser.min.js` build artifact.

--- a/.changeset/spicy-carrots-love.md
+++ b/.changeset/spicy-carrots-love.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/config": patch
+---
+
+Apply Babel Rollup plugin to `.ts` files in the `index.browser.min.js` build. It was erroneously ignoring transpiled `.ts` files before.

--- a/packages/config/rollup.js
+++ b/packages/config/rollup.js
@@ -1,3 +1,4 @@
+import { DEFAULT_EXTENSIONS as babelDefaultExtensions } from "@babel/core";
 import { babel } from "@rollup/plugin-babel";
 import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
@@ -81,6 +82,8 @@ const makeConfig = ({
         babel({
           babelHelpers: "bundled",
           extends: "@jspsych/config/babel",
+          // https://github.com/ezolenko/rollup-plugin-typescript2#rollupplugin-babel
+          extensions: [...babelDefaultExtensions, ".ts"],
         })
       ),
       output: [


### PR DESCRIPTION
:facepalm:

I managed to overlook [this notice](https://github.com/ezolenko/rollup-plugin-typescript2#rollupplugin-babel) in the `rollup-plugin-typescript2` docs. As a consequence, none of our `index.browser.min.js` builds has ever had Babel applied to it :facepalm: