### PR TITLE
Fix slider appearance in canvas-slider-response

### DIFF
--- a/.changeset/cold-dancers-cover.md
+++ b/.changeset/cold-dancers-cover.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/plugin-canvas-slider-response": patch
+---
+
+Fixed a bug where the jspsych-slider class was not applied to the input range element.

--- a/packages/plugin-canvas-slider-response/src/index.ts
+++ b/packages/plugin-canvas-slider-response/src/index.ts
@@ -127,7 +127,7 @@ class CanvasSliderResponsePlugin implements JsPsychPlugin<Info> {
     }
     html += '">';
     html +=
-      '<input type="range" value="' +
+      '<input type="range" class="jspsych-slider" value="' +
       trial.slider_start +
       '" min="' +
       trial.min +


### PR DESCRIPTION
This adds the `jspsych-slider` class to the `<input type="range">` element in the canvas-slider plugin to make it consistent with other slider plugins.

Reported in #2636.