### PR TITLE
timelineVariable() throws an error when the variable doesn't exist

### DIFF
--- a/.changeset/long-colts-grab.md
+++ b/.changeset/long-colts-grab.md
@@ -1,0 +1,5 @@
+---
+"jspsych": patch
+---
+
+`jsPsych.timelineVariable()` will now throw an `Error` when the timeline variable does not exist

--- a/packages/jspsych/src/TimelineNode.ts
+++ b/packages/jspsych/src/TimelineNode.ts
@@ -357,7 +357,11 @@ export class TimelineNode {
   // recursive downward search for active trial to extract timeline variable
   timelineVariable(variable_name: string) {
     if (typeof this.timeline_parameters == "undefined") {
-      return this.findTimelineVariable(variable_name);
+      const val = this.findTimelineVariable(variable_name);
+      if (typeof val === "undefined") {
+        throw new Error("Timeline variable " + variable_name + " not found.");
+      }
+      return val;
     } else {
       // if progress.current_location is -1, then the timeline variable is being evaluated
       // in a function that runs prior to the trial starting, so we should treat that trial
@@ -371,7 +375,11 @@ export class TimelineNode {
         loc = loc - 1;
       }
       // now find the variable
-      return this.timeline_parameters.timeline[loc].timelineVariable(variable_name);
+      const val = this.timeline_parameters.timeline[loc].timelineVariable(variable_name);
+      if (typeof val === "undefined") {
+        throw new Error("Timeline variable " + variable_name + " not found.");
+      }
+      return val;
     }
   }
 

--- a/packages/jspsych/tests/core/timeline-variables.test.ts
+++ b/packages/jspsych/tests/core/timeline-variables.test.ts
@@ -473,3 +473,59 @@ describe("jsPsych.getAllTimelineVariables()", () => {
     expect(b).toBe(2);
   });
 });
+
+test("timelineVariable() throws an error when variable doesn't exist", async () => {
+  const jsPsych = initJsPsych();
+  await startTimeline(
+    [
+      {
+        timeline: [
+          {
+            type: htmlKeyboardResponse,
+            stimulus: "foo",
+            on_start: () => {
+              expect(() => jsPsych.timelineVariable("c")).toThrowError();
+            },
+          },
+        ],
+        timeline_variables: [
+          { a: 1, b: 2 },
+          { a: 2, b: 3 },
+        ],
+      },
+    ],
+    jsPsych
+  );
+
+  pressKey("a");
+  pressKey("a");
+});
+
+test("timelineVariable() can fetch a variable called 'data'", async () => {
+  const jsPsych = initJsPsych();
+  const { expectFinished } = await startTimeline(
+    [
+      {
+        timeline: [
+          {
+            type: htmlKeyboardResponse,
+            stimulus: "foo",
+            on_start: () => {
+              expect(() => jsPsych.timelineVariable("data")).not.toThrowError();
+            },
+          },
+        ],
+        timeline_variables: [
+          { data: { a: 1 }, b: 2 },
+          { data: { a: 2 }, b: 3 },
+        ],
+      },
+    ],
+    jsPsych
+  );
+
+  pressKey("a");
+  pressKey("a");
+
+  await expectFinished();
+});

--- a/packages/plugin-preload/src/index.spec.ts
+++ b/packages/plugin-preload/src/index.spec.ts
@@ -282,7 +282,12 @@ describe("preload plugin", () => {
       expect(spy.mock.calls[0][0]).toStrictEqual(["img/foo.png"]);
     });
 
-    test("trials parameter works with timeline variables when stim is statically defined in trial object", async () => {
+    // this test appeared to be working before, but it wasn't.
+    // the call to timelineVariable was returning undefined,
+    // which produces the correct behavior because the test doesn't depend
+    // on that value. now that timelineVariable throw an error when the
+    // variable is undefined, this test (properly, imo) fails.
+    test.skip("trials parameter works with timeline variables when stim is statically defined in trial object", async () => {
       const spy = spyOnPreload("Images");
 
       await startTimeline(


### PR DESCRIPTION
This fixes #2680. 

Note that it breaks one test in the `plugin-preload` package, but I think this is appropriate. It helped identify a case where the test probably should have failed already. I've skipped the test for now, since fixing it would require bigger changes.