### PR TITLE
Fix preload plugin onerror callback

### DIFF
--- a/.changeset/bright-tables-provide.md
+++ b/.changeset/bright-tables-provide.md
@@ -1,0 +1,5 @@
+---
+"jspsych": patch
+---
+
+Fix preload plugin onerror callback so that it returns proper src information when there are 404 errors.

--- a/packages/jspsych/src/modules/plugin-api/MediaAPI.ts
+++ b/packages/jspsych/src/modules/plugin-api/MediaAPI.ts
@@ -176,24 +176,24 @@ export class MediaAPI {
       return;
     }
 
-    for (var i = 0; i < images.length; i++) {
-      var img = new Image();
-
-      img.onload = function () {
+    for (let i = 0; i < images.length; i++) {
+      const img = new Image();
+      const src = images[i];
+      img.onload = () => {
         n_loaded++;
-        callback_load(img.src);
+        callback_load(src);
         if (n_loaded === images.length) {
           callback_complete();
         }
       };
 
-      img.onerror = function (e) {
-        callback_error({ source: img.src, error: e });
+      img.onerror = (e) => {
+        callback_error({ source: src, error: e });
       };
 
-      img.src = images[i];
+      img.src = src;
 
-      this.img_cache[images[i]] = img;
+      this.img_cache[src] = img;
       this.preload_requests.push(img);
     }
   }

--- a/packages/jspsych/src/modules/plugin-api/MediaAPI.ts
+++ b/packages/jspsych/src/modules/plugin-api/MediaAPI.ts
@@ -102,15 +102,15 @@ export class MediaAPI {
           }
         );
       };
-      request.onerror = function (e) {
+      request.onerror = (e) => {
         let err: ProgressEvent | string = e;
-        if (this.status == 404) {
+        if (request.status == 404) {
           err = "404";
         }
         callback_error({ source: source, error: err });
       };
-      request.onloadend = function (e) {
-        if (this.status == 404) {
+      request.onloadend = (e) => {
+        if (request.status == 404) {
           callback_error({ source: source, error: "404" });
         }
       };
@@ -221,9 +221,9 @@ export class MediaAPI {
       const request = new XMLHttpRequest();
       request.open("GET", video, true);
       request.responseType = "blob";
-      request.onload = function () {
-        if (this.status === 200 || this.status === 0) {
-          const videoBlob = this.response;
+      request.onload =  () => {
+        if (request.status === 200 || request.status === 0) {
+          const videoBlob = request.response;
           video_buffers[video] = URL.createObjectURL(videoBlob); // IE10+
           n_loaded++;
           callback_load(video);
@@ -232,15 +232,15 @@ export class MediaAPI {
           }
         }
       };
-      request.onerror = function (e) {
+      request.onerror =  (e) => {
         let err: ProgressEvent | string = e;
-        if (this.status == 404) {
+        if (request.status == 404) {
           err = "404";
         }
         callback_error({ source: video, error: err });
       };
-      request.onloadend = function (e) {
-        if (this.status == 404) {
+      request.onloadend =  (e) => {
+        if (request.status == 404) {
           callback_error({ source: video, error: "404" });
         }
       };


### PR DESCRIPTION
Fix MediaAPI preloadImages onerror callback.

## Expected Behavior
Given a preload trial:
```
var preload = {
      type: jsPsychPreload,
      images: ['blue.png', 'orange.png'],
      continue_after_error: true,
    };
```
With a 404 response code for blue.png and orange.png.

I'd expect the preload trial data to contains:
failed_images:
- "https://vecvqftksb.cognitive.test/preview1661654938625/orange.png" 
- "https://vecvqftksb.cognitive.test/preview1661654938625/blue.png" 


## Current Behavior
Preload trial data has:
- "https://vecvqftksb.cognitive.test/preview1661654938625/orange.png" 
- "https://vecvqftksb.cognitive.test/preview1661654938625/orange.png" 

## Possible Solution
Implement Javascript closure on media onerror callback by replacing function syntax with arrow functions.

## Steps to Reproduce
1. Follow [Simple Reaction Time tutorial](https://www.jspsych.org/7.3/tutorials/rt-task/) steps to create a task.
2. Do not save orange.png and blue.png in your server.
3. Modify preload trial to include `continue_after_error: true` setting.
4. Run the experiment.
5. Once you see 'Welcome to the experiment.', check Jspsych stored data.

## Context (Environment)
When you are preloading 1000 stimuli, the experiment will fail if one of them is missing.

At Cognition.run I'm trying to help users detect which stimuli is missing.

Fixing this issue would allow me to capture the list of missing stimuli and display them on the UI.

## Detailed Description

The problem is about scopes and callback functions. A wrong variable scope is causing multiple callbacks to share the same variable. Each callback should has his own variables and scopes.

What I'm doing here is to change all media preloading functions (audio, image and video), so the onerror callbacks use arrow functions instead of function syntax. Why? Because this creates a closure that keeps the value of `source` variable overtime for this specific callback.

