### PR TITLE
Fixes `shuffleNoRepeats` when the equality test contains a logical OR

### DIFF
--- a/.changeset/perfect-pugs-add.md
+++ b/.changeset/perfect-pugs-add.md
@@ -1,0 +1,5 @@
+---
+"jspsych": patch
+---
+
+Fixed a bug in `randomization.shuffleNoRepeats()` where having an `equalityFunction` that used a logical OR could result in some neighboring elements still evaluating to `true` via `equalityFunction`.

--- a/packages/jspsych/src/modules/randomization.ts
+++ b/packages/jspsych/src/modules/randomization.ts
@@ -120,6 +120,7 @@ export function shuffleNoRepeats(arr: Array<any>, equalityTest: (a: any, b: any)
   }
 
   const random_shuffle = shuffle(arr);
+
   for (let i = 0; i < random_shuffle.length - 1; i++) {
     if (equalityTest(random_shuffle[i], random_shuffle[i + 1])) {
       // neighbors are equal, pick a new random neighbor to swap (not the first or last element, to avoid edge cases)
@@ -128,7 +129,8 @@ export function shuffleNoRepeats(arr: Array<any>, equalityTest: (a: any, b: any)
       while (
         equalityTest(random_shuffle[i + 1], random_shuffle[random_pick]) ||
         equalityTest(random_shuffle[i + 1], random_shuffle[random_pick + 1]) ||
-        equalityTest(random_shuffle[i + 1], random_shuffle[random_pick - 1])
+        equalityTest(random_shuffle[i + 1], random_shuffle[random_pick - 1]) ||
+        equalityTest(random_shuffle[i], random_shuffle[random_pick])
       ) {
         random_pick = Math.floor(Math.random() * (random_shuffle.length - 2)) + 1;
       }

--- a/packages/jspsych/tests/randomization/randomization.test.ts
+++ b/packages/jspsych/tests/randomization/randomization.test.ts
@@ -147,6 +147,29 @@ describe("shuffleNoRepeats", function () {
     }
     expect(repeats).toBe(0);
   });
+
+  test("should generate a random order with no repeats using objects", function () {
+    var equalityTest = (a, b) => a.color === b.color || a.word === b.word;
+    var toShuffle = [
+      { color: "red", word: "red" },
+      { color: "red", word: "blue" },
+      { color: "blue", word: "blue" },
+      { color: "blue", word: "red" },
+      { color: "green", word: "green" },
+      { color: "green", word: "yellow" },
+      { color: "yellow", word: "yellow" },
+      { color: "yellow", word: "green" },
+    ];
+    var repeated = repeat(toShuffle, 20);
+    var randomOrder = shuffleNoRepeats(repeated, equalityTest);
+    var repeats = 0;
+    for (var i = 1; i < randomOrder.length; i++) {
+      if (equalityTest(randomOrder[i], randomOrder[i - 1])) {
+        repeats++;
+      }
+    }
+    expect(repeats).toBe(0);
+  });
 });
 
 describe("randomInt", () => {


### PR DESCRIPTION
When the `equalityTest` function contains a logical OR then equality could be satisified in different ways, and this led to cases where the one-pass method through the array failed.

This fixes #2810 by adding an additional check to ensure that swapped elements are not violating the equality check.