### PR TITLE
fixed browser-check typo in doc example

### DIFF
--- a/docs/demos/jspsych-browser-check-demo2.html
+++ b/docs/demos/jspsych-browser-check-demo2.html
@@ -17,7 +17,9 @@
       inclusion_function: (data) => {
         return ['chrome', 'firefox'].includes(data.browser);
       },
-      exclusion_message: `<p>You must use Chrome or Firefox to complete this experiment.</p>`
+      exclusion_message: (data) => {
+            return `<p>You must use Chrome or Firefox to complete this experiment.</p>`
+      },
     };
 
     const timeline = [trial];

--- a/docs/plugins/browser-check.md
+++ b/docs/plugins/browser-check.md
@@ -123,7 +123,9 @@ import browserCheck from '@jspsych/plugin-browser-check';
           inclusion_function: (data) => {
             return ['chrome', 'firefox'].includes(data.browser);
           },
-          exclusion_message: `<p>You must use Chrome or Firefox to complete this experiment.</p>`
+          exclusion_message: (data) => {
+            return `<p>You must use Chrome or Firefox to complete this experiment.</p>`
+          },
         };
         ``` 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36463283/196475006-cf69bed8-9b3b-4578-a0fd-327828606968.png)

Fixed typo in browser-check example "Using the inclusion function to mandate the use of Chrome or Firefox as the browser". The example raises "Uncaught (in promise) TypeError: this.t.exclusion_message is not a function" when loaded in excluded browser because "exclusion_message" is not a function.