### PR TITLE
Handle permission rejection from camera/microphone

### DIFF
--- a/.changeset/cool-creatures-crawl.md
+++ b/.changeset/cool-creatures-crawl.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/plugin-html-audio-response": patch
+---
+
+added error handling if a microphone is not detected on trial start

--- a/.changeset/fluffy-books-act.md
+++ b/.changeset/fluffy-books-act.md
@@ -1,6 +1,5 @@
 ---
-"@jspsych/plugin-html-audio-response": minor
-"@jspsych/plugin-html-video-response": minor
+"@jspsych/plugin-html-video-response": patch
 ---
 
-added handling and a custom rejection message if the media device does not have access permissions
+added error handling if a camera is not detected on trial start

--- a/.changeset/fluffy-books-act.md
+++ b/.changeset/fluffy-books-act.md
@@ -1,0 +1,6 @@
+---
+"@jspsych/plugin-html-audio-response": minor
+"@jspsych/plugin-html-video-response": minor
+---
+
+added handling and a custom rejection message if the media device does not have access permissions

--- a/.changeset/hungry-elephants-jam.md
+++ b/.changeset/hungry-elephants-jam.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/plugin-initialize-microphone": patch
+---
+
+added error handling if permission to the microphone is rejected

--- a/.changeset/hungry-elephants-jam.md
+++ b/.changeset/hungry-elephants-jam.md
@@ -1,5 +1,5 @@
 ---
-"@jspsych/plugin-initialize-microphone": patch
+"@jspsych/plugin-initialize-microphone": minor
 ---
 
-added error handling if permission to the microphone is rejected
+added custom rejection message upon microphone permission denial

--- a/.changeset/poor-cherries-pay.md
+++ b/.changeset/poor-cherries-pay.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/plugin-initialize-camera": patch
+---
+
+added error handling if permission to the camera is rejected

--- a/.changeset/poor-cherries-pay.md
+++ b/.changeset/poor-cherries-pay.md
@@ -1,5 +1,5 @@
 ---
-"@jspsych/plugin-initialize-camera": patch
+"@jspsych/plugin-initialize-camera": minor
 ---
 
-added error handling if permission to the camera is rejected
+added custom rejection message upon camera permission denial

--- a/.changeset/violet-hairs-tap.md
+++ b/.changeset/violet-hairs-tap.md
@@ -1,5 +1,0 @@
----
-"@jspsych/plugin-cloze": minor
----
-
-added `allow_blanks` as a field, allowing for completion checking of answers

--- a/docs/plugins/initialize-camera.md
+++ b/docs/plugins/initialize-camera.md
@@ -18,11 +18,12 @@ In addition to the [parameters available in all plugins](../overview/plugins.md#
 Parameter | Type | Default Value | Description
 ----------|------|---------------|------------
 device_select_message | html string | `<p>Please select the camera you would like to use.</p>` | The message to display when the user is presented with a dropdown list of available devices.
-button_label | sting | 'Use this camera.' | The label for the select button.
+button_label | string | 'Use this camera.' | The label for the select button.
 include_audio | bool | false | Set to `true` to include an audio track in the recordings.
 width | int | null | Request a specific width for the recording. This is not a guarantee that this width will be used, as it depends on the capabilities of the participant's device. Learn more about `MediaRecorder` constraints [here](https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API/Constraints#requesting_a_specific_value_for_a_setting).
 height | int | null | Request a specific height for the recording. This is not a guarantee that this height will be used, as it depends on the capabilities of the participant's device. Learn more about `MediaRecorder` constraints [here](https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API/Constraints#requesting_a_specific_value_for_a_setting).
 mime_type | string | null | Set this to use a specific [MIME type](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/mimeType) for the recording. Set the entire type, e.g., `'video/mp4; codecs="avc1.424028, mp4a.40.2"'`.
+rejection_message | html string | `<p>You must allow access to a camera in order to participate in the experiment.</p>` | The message to display if the user rejects access to the camera.
 
 
 ## Data Generated

--- a/docs/plugins/initialize-microphone.md
+++ b/docs/plugins/initialize-microphone.md
@@ -18,7 +18,8 @@ In addition to the [parameters available in all plugins](../overview/plugins.md#
 Parameter | Type | Default Value | Description
 ----------|------|---------------|------------
 device_select_message | html string | `<p>Please select the microphone you would like to use.</p>` | The message to display when the user is presented with a dropdown list of available devices.
-button_label | sting | 'Use this microphone.' | The label for the select button.
+button_label | string | 'Use this microphone.' | The label for the select button.
+rejection_message | html string | `<p>You must allow access to a microphone in order to participate in the experiment.</p>` | The message to display if the user rejects access to the microphone.
 
 
 ## Data Generated

--- a/examples/jspsych-initialize-camera.html
+++ b/examples/jspsych-initialize-camera.html
@@ -1,20 +1,28 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <script src="../packages/jspsych/dist/index.browser.js"></script>
-  <script src="../packages/plugin-initialize-camera/dist/index.browser.js"></script>
-  <link rel="stylesheet" href="../packages/jspsych/css/jspsych.css">
-</head>
-<body></body>
-<script>
+  <head>
+    <script src="../packages/jspsych/dist/index.browser.js"></script>
+    <script src="../packages/plugin-initialize-camera/dist/index.browser.js"></script>
+    <script src="../packages/plugin-html-video-response/dist/index.browser.js"></script>
+    <link rel="stylesheet" href="../packages/jspsych/css/jspsych.css" />
+  </head>
+  <body></body>
+  <script>
 
-  var jsPsych = initJsPsych();
+      var jsPsych = initJsPsych();
 
-  let init_camera = {
-    type: jsPsychInitializeCamera,
-  }
+      let init_camera = {
+        type: jsPsychInitializeCamera,
+      }
 
-  jsPsych.run([init_camera]);
+      let vr = {
+        type: jsPsychHtmlVideoResponse,
+        stimulus: `<p>Make a sad face</p>`,
+        recording_duration: 3500,
+        show_done_button: false,
+        allow_playback: true
+    };
 
-</script>
+      jsPsych.run([init_camera, vr]);
+  </script>
 </html>

--- a/packages/plugin-html-audio-response/src/index.ts
+++ b/packages/plugin-html-audio-response/src/index.ts
@@ -73,10 +73,14 @@ class HtmlAudioResponsePlugin implements JsPsychPlugin<Info> {
   private data_available_handler;
   private recorded_data_chunks = [];
 
-  constructor(private jsPsych: JsPsych) {}
+  constructor(private jsPsych: JsPsych) { }
 
   trial(display_element: HTMLElement, trial: TrialType<Info>) {
     this.recorder = this.jsPsych.pluginAPI.getMicrophoneRecorder();
+
+    if (this.recorder === null) {
+      throw new Error('Error in html-audio-response plugin. A microphone has not been found, have you ran the initialize-microphone plugin?');
+    }
 
     this.setupRecordingEvents(display_element, trial);
 

--- a/packages/plugin-html-video-response/src/index.ts
+++ b/packages/plugin-html-video-response/src/index.ts
@@ -73,10 +73,14 @@ class HtmlVideoResponsePlugin implements JsPsychPlugin<Info> {
   private data_available_handler;
   private recorded_data_chunks = [];
 
-  constructor(private jsPsych: JsPsych) {}
+  constructor(private jsPsych: JsPsych) { }
 
   trial(display_element: HTMLElement, trial: TrialType<Info>) {
     this.recorder = this.jsPsych.pluginAPI.getCameraRecorder();
+
+    if (this.recorder === null) {
+     throw new Error("Error in html-video-response plugin. A camera has not been found, have you ran the initialize-camera plugin?");
+    }
 
     this.setupRecordingEvents(display_element, trial);
 

--- a/packages/plugin-initialize-camera/src/index.ts
+++ b/packages/plugin-initialize-camera/src/index.ts
@@ -33,6 +33,11 @@ const info = <const>{
       type: ParameterType.STRING,
       default: null,
     },
+    /** The message to display when permission to access the camera is rejected. */
+    rejection_message: {
+      type: ParameterType.HTML_STRING,
+      default: `<p>You must allow access to a camera in order to participate in the experiment.</p>`,
+    },
   },
 };
 
@@ -61,7 +66,15 @@ class InitializeCameraPlugin implements JsPsychPlugin<Info> {
   }
 
   private async run_trial(display_element: HTMLElement, trial: TrialType<Info>) {
-    await this.askForPermission(trial);
+    try {
+      console.log("test1")
+      await this.askForPermission(trial);
+    } catch (e) {
+      console.log("test")
+      // TODO: does not properly display rejection message
+      this.rejectPermission(trial);
+      return;
+    }
 
     this.showCameraSelection(display_element, trial);
 
@@ -146,6 +159,12 @@ class InitializeCameraPlugin implements JsPsychPlugin<Info> {
         display_element.querySelector("#which-camera").appendChild(el);
       });
     });
+  }
+
+  private rejectPermission(trial: TrialType<Info>) {
+    this.jsPsych.getDisplayElement().innerHTML = "";
+
+    this.jsPsych.endExperiment(trial.rejection_message, {});
   }
 }
 

--- a/packages/plugin-initialize-camera/src/index.ts
+++ b/packages/plugin-initialize-camera/src/index.ts
@@ -54,7 +54,7 @@ type Info = typeof info;
 class InitializeCameraPlugin implements JsPsychPlugin<Info> {
   static info = info;
 
-  constructor(private jsPsych: JsPsych) {}
+  constructor(private jsPsych: JsPsych) { }
 
   trial(display_element: HTMLElement, trial: TrialType<Info>) {
     this.run_trial(display_element, trial).then((id) => {
@@ -67,10 +67,8 @@ class InitializeCameraPlugin implements JsPsychPlugin<Info> {
 
   private async run_trial(display_element: HTMLElement, trial: TrialType<Info>) {
     try {
-      console.log("test1")
       await this.askForPermission(trial);
     } catch (e) {
-      console.log("test")
       // TODO: does not properly display rejection message
       this.rejectPermission(trial);
       return;


### PR DESCRIPTION
hi all, this PR is made in regards to #2522, by adding a warning message for those who try to initialize the `html-video-response` or `html-audio-response` plugins. along with this, the `initialize-camera` and `initialize-microphone` plugins now allow the user to give a custom rejection message if the participant rejects the use of the camera/microphone. 

IMPORTANT TO NOTE: for some reason, the `initialize-camera` plugin does not play well with camera rejection, and will not display the rejection message. was wondering if this was only the case on my machine, or on others too because the code i used for both rejection mechanisms are the same.