### PR TITLE
fix for wrong audio mimetype preventing playback in Safari

### DIFF
--- a/.changeset/pink-ducks-think.md
+++ b/.changeset/pink-ducks-think.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/plugin-html-audio-response": patch
+---
+
+uses mimetype of audio recorded for playback instead of defaulting to webm

--- a/packages/plugin-html-audio-response/src/index.ts
+++ b/packages/plugin-html-audio-response/src/index.ts
@@ -133,7 +133,7 @@ class HtmlAudioResponsePlugin implements JsPsychPlugin<Info> {
     };
 
     this.stop_event_handler = () => {
-      const data = new Blob(this.recorded_data_chunks, { type: "audio/webm" });
+      const data = new Blob(this.recorded_data_chunks, { type: this.recorded_data_chunks[0].type });
       this.audio_url = URL.createObjectURL(data);
       const reader = new FileReader();
       reader.addEventListener("load", () => {


### PR DESCRIPTION
Hello,

While preparing an experiment using the html audio response plugin, I found out that playback of recorded audio (using `{allow_playback: true}`) doesn't work in Safari (tested on 16.3).
This happens because the audio mimetype is hardcoded as "audio/webm" while Safari is using mp4. From what I've seen, Chrome is indeed recording webm, and Firefox seems to work regardless of this mismatch.

Anyway, the fix here would be to just use whatever is provided in  `recorded_data_chunks`.

Thanks!