### PR TITLE
Change `DataColumn.mean()` to ignore `null` and `undefined` values

### DIFF
--- a/.changeset/forty-weeks-walk.md
+++ b/.changeset/forty-weeks-walk.md
@@ -1,0 +1,5 @@
+---
+"jspsych": major
+---
+
+Changed the behavior of `DataColumn.mean()` to exclude `null` and `undefined` values from the calculation, as suggested in #2905

--- a/packages/jspsych/src/modules/data/DataColumn.ts
+++ b/packages/jspsych/src/modules/data/DataColumn.ts
@@ -10,7 +10,18 @@ export class DataColumn {
   }
 
   mean() {
-    return this.sum() / this.count();
+    let sum = 0;
+    let count = 0;
+    for (const value of this.values) {
+      if (typeof value !== "undefined" && value !== null) {
+        sum += value;
+        count++;
+      }
+    }
+    if (count === 0) {
+      return undefined;
+    }
+    return sum / count;
   }
 
   median() {


### PR DESCRIPTION
Fixes #2905 