### PR TITLE
add optional isDeepCopy to shuffle & 2 tests for the same

### DIFF
--- a/packages/jspsych/src/modules/randomization.ts
+++ b/packages/jspsych/src/modules/randomization.ts
@@ -1,6 +1,8 @@
 import rw from "random-words";
 import seedrandom from "seedrandom/lib/alea";
 
+import { deepCopy } from "./utils";
+
 /**
  * Uses the `seedrandom` package to replace Math.random() with a seedable PRNG.
  *
@@ -77,12 +79,13 @@ export function repeat(array, repetitions, unpack = false) {
   return out;
 }
 
-export function shuffle(array: Array<any>) {
+export function shuffle(array: Array<any>, isDeepCopy?: boolean) {
   if (!Array.isArray(array)) {
     console.error("Argument to shuffle() must be an array.");
   }
 
-  const copy_array = array.slice(0);
+  const copy_array = isDeepCopy ? deepCopy(array) : array.slice(0);
+
   let m = copy_array.length,
     t,
     i;

--- a/packages/jspsych/tests/randomization/randomization.test.ts
+++ b/packages/jspsych/tests/randomization/randomization.test.ts
@@ -50,6 +50,24 @@ describe("shuffle", () => {
     expect(shuffledArray[0]).not.toBe(array[0]);
     expect(array[1]).toEqual([-1, 5, 6]);
   });
+
+  it('should return shallow copy when isDeepCopy is set to "false" by default', () => {
+    const array1 = [1, 2, 3];
+    const array2 = [4, 5, 6];
+    const array3 = [7, 8, 9];
+    const array = [array1, array2, array3];
+
+    const shuffledArray = shuffle(array);
+
+    array2[0] = -1;
+
+    expect(shuffledArray).toEqual([
+      [1, 2, 3],
+      [7, 8, 9],
+      [-1, 5, 6],
+    ]);
+    expect(shuffledArray[0]).toBe(array[0]);
+  });
 });
 
 describe("shuffleAlternateGroups", () => {

--- a/packages/jspsych/tests/randomization/randomization.test.ts
+++ b/packages/jspsych/tests/randomization/randomization.test.ts
@@ -31,6 +31,25 @@ describe("shuffle", () => {
     expect(shuffledArray).not.toBe(array);
     expect(shuffledArray).toEqual([1, 3, 2]);
   });
+
+  it('should return deep copy when isDeepCopy set to "true"', () => {
+    const array1 = [1, 2, 3];
+    const array2 = [4, 5, 6];
+    const array3 = [7, 8, 9];
+    const array = [array1, array2, array3];
+
+    const shuffledArray = shuffle(array, true);
+
+    array2[0] = -1;
+
+    expect(shuffledArray).toEqual([
+      [1, 2, 3],
+      [7, 8, 9],
+      [4, 5, 6],
+    ]);
+    expect(shuffledArray[0]).not.toBe(array[0]);
+    expect(array[1]).toEqual([-1, 5, 6]);
+  });
 });
 
 describe("shuffleAlternateGroups", () => {


### PR DESCRIPTION
To address the issue in #2808 and its comments, I added the optional isDeepCopy input parameter to the shuffle method. Now if people want to have a deep copy of the array that's to be shuffled, they can simply set it to be true, while the default only returns a shallow copy or they can manually set it to false. 

I added 2 tests in the the randomization test suite for the same. 