### PR TITLE
Update canvas version in config

### DIFF
--- a/.changeset/odd-pigs-travel.md
+++ b/.changeset/odd-pigs-travel.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/config": patch
+---
+
+Update `canvas` package dependency version to fix missing binaries issues with newer node/npm versions

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -50,7 +50,7 @@
     "@types/gulp": "4.0.9",
     "@types/jest": "27.5.1",
     "babel-preset-minify": "0.5.2",
-    "canvas": "2.9.1",
+    "canvas": "2.11.2",
     "gulp": "4.0.2",
     "gulp-cli": "2.3.0",
     "gulp-file": "^0.4.0",


### PR DESCRIPTION
This fixes issues with binaries being unavailable for the canvas package in newer versions of node.