### PR TITLE
WIP: Add internationalization (i.e. translations and more) support

### DIFF
--- a/packages/jspsych/tests/core/i18n.test.ts
+++ b/packages/jspsych/tests/core/i18n.test.ts
@@ -1,0 +1,73 @@
+import htmlKeyboardResponse from "@jspsych/plugin-html-keyboard-response";
+import { pressKey, startTimeline } from "@jspsych/test-utils";
+
+import { initJsPsych } from "../../src";
+
+describe("translations are correctly fetched", () => {
+  test("when drawing from the global translations", async () => {
+    const jsPsych = initJsPsych({
+      locale: "de",
+      translations: {
+        de: {
+          "Hello World!": "Hallo Welt!",
+        },
+      },
+    });
+    const { getHTML } = await startTimeline(
+      [
+        {
+          type: htmlKeyboardResponse,
+          stimulus: () => jsPsych.translate("Hello World!"),
+          on_finish: () => {
+            jsPsych.setLocale("en");
+          },
+        },
+        {
+          type: htmlKeyboardResponse,
+          stimulus: () => jsPsych.translate("Hello World!"),
+        },
+      ],
+      jsPsych
+    );
+
+    expect(getHTML()).toMatch("Hallo Welt!");
+    pressKey("a");
+    expect(getHTML()).toMatch("Hello World!");
+  });
+
+  test("when drawing from trial-level translations", async () => {
+    const jsPsych = initJsPsych({
+      locale: "de",
+    });
+    const { getHTML } = await startTimeline(
+      [
+        {
+          type: htmlKeyboardResponse,
+          stimulus: () => jsPsych.translate("Hello World!"),
+          translations: {
+            de: {
+              "Hello World!": "Hallo Welt!",
+            },
+          },
+          on_finish: () => {
+            jsPsych.setLocale("en");
+          },
+        },
+        {
+          type: htmlKeyboardResponse,
+          stimulus: () => jsPsych.translate("Hello World!"),
+          translations: {
+            de: {
+              "Hello World!": "Hallo Welt!",
+            },
+          },
+        },
+      ],
+      jsPsych
+    );
+
+    expect(getHTML()).toMatch("Hallo Welt!");
+    pressKey("a");
+    expect(getHTML()).toMatch("Hello World!");
+  });
+});


### PR DESCRIPTION
This (currently WIP) PR adds support for internationalization i.e. translations and all other necessary features to make experiments available in different languages / locales.

Feedback and ideas are welcome.

**(Non-Exhaustive) Todo List:**

- [x] Simple string based translations: turn `Hello World!` to `Hallo Welt!`
- [ ] String interpolation: turn `Hello {name}!` to `Hallo {name}!`
- [ ] Pluralization
- [ ] Formatting of Dates, Numbers
- [ ] Warnings for potential issues e.g. warn for certain locales when Keyboard keys are used that may be at a different location for that locale?
  - [ ] via `translateKeyboard(['a'])`; KeyboardMap API
- [ ] Styling that needs to be adjusted?
  - [ ] Right-aligned text
  - [ ] Forms
- [ ] Check support for (automated) translation tools
- [ ] Write docs page
- [ ] Create a language selection plugin (maybe separate PR)