### PR TITLE
fix broken "eye-tracking-with-webgazer" demo page 

### DIFF
--- a/docs/demos/eye-tracking-with-webgazer.html
+++ b/docs/demos/eye-tracking-with-webgazer.html
@@ -121,7 +121,7 @@
       }
 
       var begin = {
-        type: jsPsychHtmKeyboardResponse,
+        type: jsPsychHtmlKeyboardResponse,
         stimulus: `<p>The next screen will show an image to demonstrate adding the webgazer extension to a trial.</p>
           <p>Just look at the image while eye tracking data is collected. The trial will end automatically.</p>
           <p>Press any key to start.</p>
@@ -142,7 +142,7 @@
       }
 
       var show_data = {
-        type: jsPsychHtmKeyboardResponse,
+        type: jsPsychHtmlKeyboardResponse,
         stimulus: function() {
           var trial_data = jsPsych.data.getLastTrialData().values();
           var trial_json = JSON.stringify(trial_data, null, 2);


### PR DESCRIPTION
# Why 

<img width="1436" alt="image" src="https://github.com/jspsych/jsPsych/assets/5466631/de7bb80f-b4b7-45b1-959b-e0bba1db1d66">

I noticed that the "eye-tracking-with-webgazer" demo page is currently broken

The error message I encountered: 
`"Uncaught ReferenceError: jsPsychHtmKeyboardResponse is not defined."`

refs:
- https://www.jspsych.org/7.0/demos/eye-tracking-with-webgazer.html
- https://www.jspsych.org/7.3/overview/eye-tracking/#example

# What

- fix typo `jsPsychHtmKeyboardResponse` -> `jsPsychHtmlKeyboardResponse` (missing `l`)