### PR TITLE
Add `response_ends_trial` for visual search circle plugin

### DIFF
--- a/.changeset/strong-ligers-join.md
+++ b/.changeset/strong-ligers-join.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/plugin-visual-search-circle": minor
+---
+
+Adds response_ends_trial parameter, with a default value of `true`

--- a/docs/plugins/visual-search-circle.md
+++ b/docs/plugins/visual-search-circle.md
@@ -32,6 +32,7 @@ The `target_present` and `fixation_image` parameters must always be specified. O
 | target_absent_key  | string          | 'f'           | The key to press if the target is not present in the search array. |
 | trial_duration     | numeric         | null          | The maximum amount of time the participant is allowed to search before the trial will continue. A value of null will allow the participant to search indefinitely. |
 | fixation_duration  | numeric         | 1000          | How long to show the fixation image for before the search array (in milliseconds). |
+| response_ends_trial| boolean         | true         | If true, the trial will end when the participant makes a response. |
 
 ## Data Generated
 

--- a/packages/plugin-visual-search-circle/src/index.spec.ts
+++ b/packages/plugin-visual-search-circle/src/index.spec.ts
@@ -29,6 +29,36 @@ describe("visual-search-circle", () => {
 
     expect(getData().values()[0].correct).toBe(true);
   });
+
+  it("wait when response_ends_trial is false", async () => {
+    const { displayElement, expectFinished, expectRunning, getData } = await startTimeline([
+      {
+        type: visualSearchCircle,
+        target: "target.png",
+        foil: "foil.png",
+        fixation_image: "fixation.png",
+        set_size: 4,
+        target_present: true,
+        target_present_key: "a",
+        target_absent_key: "b",
+        response_ends_trial: false,
+        trial_duration: 1500,
+      },
+    ]);
+
+    expect(displayElement.querySelectorAll("img").length).toBe(1);
+
+    jest.advanceTimersByTime(1000); // fixation duration
+
+    expect(displayElement.querySelectorAll("img").length).toBe(5);
+    pressKey("a");
+    await expectRunning();
+
+    jest.runAllTimers();
+    await expectFinished();
+
+    expect(getData().values()[0].correct).toBe(true);
+  });
 });
 
 describe("visual-search-circle simulation", () => {


### PR DESCRIPTION
Adds `response_ends_trial` with default value of `true`.

Resolves #3210 