### PR TITLE
Update getKeyboardResponse doc

### DIFF
--- a/docs/reference/jspsych-pluginAPI.md
+++ b/docs/reference/jspsych-pluginAPI.md
@@ -157,7 +157,7 @@ The method accepts an object of parameter values (see example below). The valid 
 Parameter | Type | Description
 ----------|------|------------
 callback_function | function | The function to execute whenever a valid keyboard response is generated.
-valid_responses | array | An array of key codes or character strings representing valid responses. Responses not on the list will be ignored. An empty array indicates that all responses are acceptable.
+valid_responses | array | An array of key codes or character strings representing valid responses. Responses not on the list will be ignored. An empty array indicates that no response is acceptable.
 rt_method | string | Indicates which method of recording time to use. The `'performance'` method uses calls to `performance.now()`, which is the standard way of measuring timing in jsPsych. It is [supported by up-to-date versions of all the major browsers](http://caniuse.com/#search=performance). The `audio` method is used in conjuction with an `audio_context` (set as an additional parameter). This uses the clock time of the `audio_context` when audio stimuli are being played.
 audio_context | AudioContext object | The AudioContext of the audio file that is being played.
 audio_context_start_time | numeric | The scheduled time of the sound file in the AudioContext. This will be used as the start time.

--- a/docs/reference/jspsych-pluginAPI.md
+++ b/docs/reference/jspsych-pluginAPI.md
@@ -163,6 +163,7 @@ audio_context | AudioContext object | The AudioContext of the audio file that is
 audio_context_start_time | numeric | The scheduled time of the sound file in the AudioContext. This will be used as the start time.
 allow_held_key | boolean | If `true`, then responses will be registered from keys that are being held down. If `false`, then a held key can only register a response the first time that `getKeyboardResponse` is called for that key. For example, if a participant holds down the `A` key before the experiment starts, then the first time `getKeyboardResponse` is called, the `A` will register as a key press. However, any future calls to `getKeyboardResponse` will not register the `A` until the participant releases the key and presses it again.
 persist | boolean | If false, then the keyboard listener will only trigger the first time a valid key is pressed. If true, then it will trigger every time a valid key is pressed until it is explicitly cancelled by `jsPsych.pluginAPI.cancelKeyboardResponse` or `jsPsych.pluginAPI.cancelAllKeyboardResponses`.
+minimum_valid_rt | number | The minimum valid response time for key presses. Any key press response time that is less than this value will be treated as invalid and ignored.
 
 #### Return value
 


### PR DESCRIPTION
- fix description of `valid_responses` parameter
- add missing description of `minimum_valid_rt`