### PR TITLE
fix: adjust eye-tracking demo link relative path

### DIFF
--- a/docs/overview/eye-tracking.md
+++ b/docs/overview/eye-tracking.md
@@ -161,7 +161,7 @@ If you have tips based on your own experience please consider sharing them on ou
     Additional example experiments using WebGazer are available in the **/examples** folder of the jsPsych release. See `webgazer.html`, `webgazer_image.html`, and `webgazer_audio.html`. 
 
 !!! example
-    Here's an example of putting all of the pieces above together. This example also shows how to use data from the validation to decide whether or not to recalibrate. You can <a href="/demos/eye-tracking-with-webgazer.html" target="_blank">try this experiment here (opens in new tab)</a>.
+    Here's an example of putting all of the pieces above together. This example also shows how to use data from the validation to decide whether or not to recalibrate. You can <a href="../../demos/eye-tracking-with-webgazer.html" target="_blank">try this experiment here (opens in new tab)</a>.
 
     ```html
     <!DOCTYPE html>


### PR DESCRIPTION
# Why

- https://github.com/jspsych/jsPsych/issues/3273


# What

- update eye-tracking demo link, redirect to same version with document page