### PR TITLE
fix incorrect path in dist gulp job (build:archive)

### DIFF
--- a/.changeset/nine-mirrors-draw.md
+++ b/.changeset/nine-mirrors-draw.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/config": patch
+---
+
+This fixes an error in the gulp task that creates the dist archive for a release, which was causing the dist archive to fail.

--- a/packages/config/gulp.js
+++ b/packages/config/gulp.js
@@ -83,7 +83,7 @@ export const createCoreDistArchive = () =>
     src("packages/jspsych/css/jspsych.css").pipe(rename("/dist/jspsych.css")),
 
     // survey.css
-    src("packages/survey/css/survey.css").pipe(rename("/dist/survey.css")),
+    src("packages/plugin-survey/css/survey.css").pipe(rename("/dist/survey.css")),
 
     // Examples
     src("examples/**/*", { base: "." })


### PR DESCRIPTION
This PR fixes a file path error in the `createCoreDistArchive` gulp task (`build:archive`), which has caused the dist archive to fail in the latest release. 

I've tested this locally and can confirm that the dist build works and the `survey.css` file is included.