### PR TITLE
Add a test case for trial parameters with `null` values

### DIFF
--- a/packages/jspsych/src/timeline/Trial.spec.ts
+++ b/packages/jspsych/src/timeline/Trial.spec.ts
@@ -462,6 +462,21 @@ describe("Trial", () => {
         );
       });
 
+      it("allows null values for parameters with a non-null default value", async () => {
+        TestPlugin.setParameterInfos({
+          allowedNullString: { type: ParameterType.STRING, default: "foo" },
+        });
+
+        const trial = createTrial({ type: TestPlugin, allowedNullString: null });
+        await trial.run();
+
+        expect(trial.pluginInstance.trial).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ allowedNullString: null }),
+          expect.anything()
+        );
+      });
+
       describe("with missing required parameters", () => {
         it("errors on missing simple parameters", async () => {
           TestPlugin.setParameterInfos({ requiredString: { type: ParameterType.STRING } });


### PR DESCRIPTION
This adds a test case for #3174. It checks to make sure that a plugin parameter with a non-null default value can still accept null as a specified value. This confirms that #3174 is fixed in version 8.0.

Closes #3174 