### PR TITLE
`getKeyboardResponse` will return `key` in original case

### DIFF
--- a/.changeset/bright-apples-hope.md
+++ b/.changeset/bright-apples-hope.md
@@ -1,0 +1,5 @@
+---
+"jspsych": patch
+---
+
+`getKeyboardResponse` now returns the `key` in the original case (e.g., "Enter" instead of "enter") for easier matching to standard key event documentation.

--- a/packages/jspsych/src/modules/plugin-api/KeyboardListenerAPI.ts
+++ b/packages/jspsych/src/modules/plugin-api/KeyboardListenerAPI.ts
@@ -125,7 +125,7 @@ export class KeyboardListenerAPI {
           this.cancelKeyboardResponse(listener);
         }
 
-        callback_function({ key, rt });
+        callback_function({ key: e.key, rt });
       }
     };
 

--- a/packages/jspsych/tests/pluginAPI/pluginapi.test.ts
+++ b/packages/jspsych/tests/pluginAPI/pluginapi.test.ts
@@ -81,6 +81,18 @@ describe("#getKeyboardResponse", () => {
     await keyUp("a");
   });
 
+  test("should return the key in standard capitalization (issue #3325)", async () => {
+    const api = new KeyboardListenerAPI(getRootElement);
+
+    api.getKeyboardResponse({
+      callback_function: callback,
+      valid_responses: ["enter"],
+    });
+
+    await pressKey("Enter");
+    expect(callback).toHaveBeenCalledWith("Enter");
+  });
+
   describe("when case_sensitive_responses is false", () => {
     let api: KeyboardListenerAPI;
 

--- a/packages/jspsych/tests/pluginAPI/pluginapi.test.ts
+++ b/packages/jspsych/tests/pluginAPI/pluginapi.test.ts
@@ -90,7 +90,7 @@ describe("#getKeyboardResponse", () => {
     });
 
     await pressKey("Enter");
-    expect(callback).toHaveBeenCalledWith("Enter");
+    expect(callback).toHaveBeenCalledWith({ key: "Enter", rt: expect.any(Number) });
   });
 
   describe("when case_sensitive_responses is false", () => {


### PR DESCRIPTION
This fixes #3325.