### PR TITLE
Updates to the AudioPlayer class and audio-button-response plugin

### DIFF
--- a/packages/plugin-audio-button-response/src/index.spec.ts
+++ b/packages/plugin-audio-button-response/src/index.spec.ts
@@ -173,6 +173,89 @@ describe("audio-button-response", () => {
 
     await expectFinished();
   });
+  it("works when response_allowed_while_playing is true", async () => {
+    const jsPsych = initJsPsych({ use_webaudio: false });
+
+    const { expectFinished, expectRunning, displayElement } = await startTimeline(
+      [
+        {
+          type: audioButtonResponse,
+          stimulus: "foo.mp3",
+          choices: ["choice1"],
+          response_allowed_while_playing: true,
+        },
+      ],
+      jsPsych
+    );
+
+    await expectRunning();
+
+    clickTarget(displayElement.querySelector("button"));
+
+    await expectFinished();
+  });
+  it("does not allow reponses when response_allowed_while_playing is false and enable_button_after is set, until after set time", async () => {
+    const jsPsych = initJsPsych({ use_webaudio: false });
+
+    const { expectFinished, expectRunning, displayElement } = await startTimeline(
+      [
+        {
+          type: audioButtonResponse,
+          stimulus: "foo.mp3",
+          choices: ["choice1"],
+          response_allowed_while_playing: false,
+          enable_button_after: 1000,
+        },
+      ],
+      jsPsych
+    );
+
+    await expectRunning();
+
+    clickTarget(displayElement.querySelector("button"));
+
+    await expectRunning();
+
+    jest.advanceTimersByTime(1000);
+
+    clickTarget(displayElement.querySelector("button"));
+
+    await expectRunning();
+
+    jest.advanceTimersByTime(1000);
+
+    clickTarget(displayElement.querySelector("button"));
+
+    await expectFinished();
+  });
+  it("does not allow reponses when response_allowed_while_playing is true and enable_button_after is set, until after set time", async () => {
+    const jsPsych = initJsPsych({ use_webaudio: false });
+
+    const { expectFinished, expectRunning, displayElement } = await startTimeline(
+      [
+        {
+          type: audioButtonResponse,
+          stimulus: "foo.mp3",
+          choices: ["choice1"],
+          response_allowed_while_playing: true,
+          enable_button_after: 500,
+        },
+      ],
+      jsPsych
+    );
+
+    await expectRunning();
+
+    clickTarget(displayElement.querySelector("button"));
+
+    await expectRunning();
+
+    jest.advanceTimersByTime(500);
+
+    clickTarget(displayElement.querySelector("button"));
+
+    await expectFinished();
+  });
 
   test("enable buttons during audio playback", async () => {
     const timeline = [
@@ -190,7 +273,7 @@ describe("audio-button-response", () => {
       use_webaudio: false,
     });
 
-    const { getHTML, finished } = await startTimeline(timeline, jsPsych);
+    await startTimeline(timeline, jsPsych);
 
     const btns = document.querySelectorAll(".jspsych-html-button-response-button button");
 


### PR DESCRIPTION
**Updates to AudioPlayer class**

The AudioPlayer was storing WebAudio API source nodes as audio buffers, and this led to errors during subsequent audio plays. The class has now been updated to store WebAudio API AudioBuffers as buffers and creates source nodes for play/stop cycles and eventListeners management calls as necessary.

**Changes to plugin-audio-button-response**

The audio-button-response plugin has been updated to work with the v8 version parameter _enable_button_after_.

**Added Tests**

The audio-button-response plugin has been given additional tests to ensure _enable_button_after_ works as expected.

**Miscellaneous**

Removed timeout and HTML clear from end trial for audio-button-response. Cleaned tests.