### PR TITLE
Fixed negative rt bug in audio-button and audio-slider plugin.

### DIFF
--- a/.changeset/cuddly-coins-fold.md
+++ b/.changeset/cuddly-coins-fold.md
@@ -1,0 +1,6 @@
+---
+"@jspsych/plugin-audio-button-response": patch
+"@jspsych/plugin-audio-slider-response": patch
+---
+
+Fixed negative response times being recorded by ensuring if the AudioContext object exists, startTime is recorded with respect to that.

--- a/packages/plugin-audio-button-response/src/index.ts
+++ b/packages/plugin-audio-button-response/src/index.ts
@@ -147,8 +147,6 @@ class AudioButtonResponsePlugin implements JsPsychPlugin<Info> {
   }
 
   async trial(display_element: HTMLElement, trial: TrialType<Info>, on_load: () => void) {
-    // hold the .resolve() function from the Promise that ends the trial
-    this.trial_complete;
     this.params = trial;
     this.display = display_element;
     // setup stimulus
@@ -217,9 +215,6 @@ class AudioButtonResponsePlugin implements JsPsychPlugin<Info> {
       this.disable_buttons();
     }
 
-    // start time
-    this.startTime = performance.now();
-
     // end trial if time limit is set
     if (trial.trial_duration !== null) {
       this.jsPsych.pluginAPI.setTimeout(() => {
@@ -229,9 +224,17 @@ class AudioButtonResponsePlugin implements JsPsychPlugin<Info> {
 
     on_load();
 
+    // start time
+    this.startTime = performance.now();
+    if (this.context !== null) {
+      this.startTime = this.context.currentTime;
+    }
+
+    // start audio
     this.audio.play();
 
     return new Promise((resolve) => {
+      // hold the .resolve() function from the Promise that ends the trial
       this.trial_complete = resolve;
     });
   }

--- a/packages/plugin-audio-slider-response/src/index.ts
+++ b/packages/plugin-audio-slider-response/src/index.ts
@@ -156,8 +156,6 @@ class AudioSliderResponsePlugin implements JsPsychPlugin<Info> {
   }
 
   async trial(display_element: HTMLElement, trial: TrialType<Info>, on_load: () => void) {
-    // record webaudio context start time
-    this.startTime;
     this.params = trial;
     this.display = display_element;
     // for storing data related to response
@@ -325,7 +323,12 @@ class AudioSliderResponsePlugin implements JsPsychPlugin<Info> {
         }
       });
 
+    //record start time
     this.startTime = performance.now();
+    // record webaudio context start time
+    if (this.context !== null) {
+      this.startTime = this.context.currentTime;
+    }
 
     // start audio
     this.audio.play();


### PR DESCRIPTION
The rewriting of the audio plugins to be object-oriented and to use AudioPlayer resulted in an oversight that failed to record startTime with respect to the AudioContext object if it exists. This PR adds this required conditional logic, and this fix prevents negative response times from being recorded by the audio-slider-response and the audio-button-response plugins.