### PR TITLE
Added extension version and type to ExtensionManager.ts

### DIFF
--- a/.changeset/empty-lies-cheer.md
+++ b/.changeset/empty-lies-cheer.md
@@ -1,0 +1,5 @@
+---
+"jspsych": minor
+---
+
+ExtensionManager now uses extension instantiation data to produce version and type, and warns users if fields are missing.

--- a/.changeset/empty-lies-cheer.md
+++ b/.changeset/empty-lies-cheer.md
@@ -1,5 +1,5 @@
 ---
-"jspsych": minor
+"jspsych": patch
 ---
 
-ExtensionManager now uses extension instantiation data to produce version and type, and warns users if fields are missing.
+ExtensionManager correctly uses extension instantiation data to produce version and type, and warns users if fields are missing.

--- a/.changeset/gentle-icons-wave.md
+++ b/.changeset/gentle-icons-wave.md
@@ -1,0 +1,7 @@
+---
+"@jspsych/extension-mouse-tracking": minor
+"@jspsych/extension-record-video": minor
+"@jspsych/extension-webgazer": minor
+---
+
+Extensions now return an extension_type and extension_version when returning data (metadata purposes).

--- a/packages/extension-mouse-tracking/src/index.ts
+++ b/packages/extension-mouse-tracking/src/index.ts
@@ -155,8 +155,6 @@ class MouseTrackingExtension implements JsPsychExtension {
     }
 
     return {
-      extension_type: "mouse-tracking",
-      extension_version: version,
       mouse_tracking_data: this.currentTrialData,
       mouse_tracking_targets: Object.fromEntries(this.currentTrialTargets.entries()),
     };

--- a/packages/extension-record-video/src/index.ts
+++ b/packages/extension-record-video/src/index.ts
@@ -58,10 +58,18 @@ class RecordVideoExtension implements JsPsychExtension {
 
       if (!this.currentTrialData.record_video_data) {
         this.onUpdateCallback = () => {
-          resolve(this.currentTrialData);
+          resolve({
+            extension_type: "record-video",
+            extension_version: version,
+            ...this.currentTrialData,
+          });
         };
       } else {
-        resolve(this.currentTrialData);
+        resolve({
+          extension_type: "record-video",
+          extension_version: version,
+          ...this.currentTrialData,
+        });
       }
     });
   };

--- a/packages/extension-record-video/src/index.ts
+++ b/packages/extension-record-video/src/index.ts
@@ -58,18 +58,10 @@ class RecordVideoExtension implements JsPsychExtension {
 
       if (!this.currentTrialData.record_video_data) {
         this.onUpdateCallback = () => {
-          resolve({
-            extension_type: "record-video",
-            extension_version: version,
-            ...this.currentTrialData,
-          });
+          resolve(this.currentTrialData);
         };
       } else {
-        resolve({
-          extension_type: "record-video",
-          extension_version: version,
-          ...this.currentTrialData,
-        });
+        resolve(this.currentTrialData);
       }
     });
   };

--- a/packages/extension-webgazer/src/index.ts
+++ b/packages/extension-webgazer/src/index.ts
@@ -211,8 +211,6 @@ class WebGazerExtension implements JsPsychExtension {
 
     // send back the gazeData
     return {
-      extension_type: "webgazer",
-      extension_version: version,
       webgazer_data: this.currentTrialData,
       webgazer_targets: this.currentTrialTargets,
     };

--- a/packages/jspsych/src/ExtensionManager.spec.ts
+++ b/packages/jspsych/src/ExtensionManager.spec.ts
@@ -102,8 +102,6 @@ describe("ExtensionManager", () => {
 
       const onFinishCallback = jest.mocked(manager.extensions.test.on_finish);
       onFinishCallback.mockReturnValue({
-        extension_type: "test",
-        extension_version: "1.0",
         extension: "result",
       });
 
@@ -115,7 +113,7 @@ describe("ExtensionManager", () => {
       expect(onFinishCallback).toHaveBeenCalledWith({ my: "option" });
       expect(results).toEqual({
         extension_type: ["test"],
-        extension_version: ["1.0"],
+        extension_version: ["0.0.1"],
         extension: "result",
       });
     });

--- a/packages/jspsych/src/ExtensionManager.ts
+++ b/packages/jspsych/src/ExtensionManager.ts
@@ -93,7 +93,7 @@ export class ExtensionManager {
         }
       : {};
 
-    results.push(extensionInfos);
+    results.unshift(extensionInfos);
 
     return Object.assign({}, ...results);
   }

--- a/packages/jspsych/src/ExtensionManager.ts
+++ b/packages/jspsych/src/ExtensionManager.ts
@@ -40,9 +40,28 @@ export class ExtensionManager {
 
   public async initializeExtensions() {
     await Promise.all(
-      this.extensionsConfiguration.map(({ type, params = {} }) =>
-        this.getExtensionInstanceByClass(type).initialize(params)
-      )
+      this.extensionsConfiguration.map(({ type, params = {} }) => {
+        this.getExtensionInstanceByClass(type).initialize(params);
+
+        const extensionInfo = type["info"] as JsPsychExtensionInfo;
+
+        if (!("version" in extensionInfo) && !("data" in extensionInfo)) {
+          console.warn(
+            extensionInfo["name"],
+            "is missing the 'version' and 'data' fields. Please update extension as 'version' and 'data' will be required in v9. See https://www.jspsych.org/latest/developers/extension-development/ for more details."
+          );
+        } else if (!("version" in extensionInfo)) {
+          console.warn(
+            extensionInfo["name"],
+            "is missing the 'version' field. Please update extension as 'version' will be required in v9. See https://www.jspsych.org/latest/developers/extension-development/ for more details."
+          );
+        } else if (!("data" in extensionInfo)) {
+          console.warn(
+            extensionInfo["name"],
+            "is missing the 'data' field. Please update extension as 'data' will be required in v9. See https://www.jspsych.org/latest/developers/extension-development/ for more details."
+          );
+        }
+      })
     );
   }
 
@@ -67,14 +86,14 @@ export class ExtensionManager {
       )
     );
 
-    const extensionInfo = trialExtensionsConfiguration.length
+    const extensionInfos = trialExtensionsConfiguration.length
       ? {
-          extension_type: results.map((result) => result.extension_type),
-          extension_version: results.map((result) => result.extension_version),
+          extension_type: trialExtensionsConfiguration.map(({ type }) => type["info"].name),
+          extension_version: trialExtensionsConfiguration.map(({ type }) => type["info"].version),
         }
       : {};
 
-    results.push(extensionInfo);
+    results.push(extensionInfos);
 
     return Object.assign({}, ...results);
   }

--- a/packages/jspsych/tests/extensions/test-extension.ts
+++ b/packages/jspsych/tests/extensions/test-extension.ts
@@ -3,6 +3,8 @@ import { JsPsych, JsPsychExtension } from "../../src";
 export class TestExtension implements JsPsychExtension {
   static info = {
     name: "test",
+    version: "0.0.1",
+    data: {},
   };
 
   constructor(private jsPsych: JsPsych) {}


### PR DESCRIPTION
This PR gives JsPsych the general functionality of adding an extension's version and type to the data it generates in a trial data object. It does so by drawing the name and version from the info property of an extension's class. This PR also reverts changes made to extensions to return version and type as extra data fields. All extensions with a complete info property will now experience the benefit of their version and type being appended to their data by JsPsych.