### PR TITLE
Replace uses of Array.from() for Qualtrics compatibility

### DIFF
--- a/.changeset/poor-singers-destroy.md
+++ b/.changeset/poor-singers-destroy.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/plugin-sketchpad": patch
+---
+
+Fixed broken event handlers in the sketchpad plugin.

--- a/.changeset/sixty-bobcats-provide.md
+++ b/.changeset/sixty-bobcats-provide.md
@@ -1,0 +1,7 @@
+---
+"jspsych": minor
+"@jspsych/plugin-free-sort": minor
+"@jspsych/plugin-maxdiff": minor
+---
+
+Remove uses of Array.from()

--- a/.changeset/sixty-bobcats-provide.md
+++ b/.changeset/sixty-bobcats-provide.md
@@ -1,7 +1,7 @@
 ---
-"jspsych": minor
-"@jspsych/plugin-free-sort": minor
-"@jspsych/plugin-maxdiff": minor
+"jspsych": patch
+"@jspsych/plugin-free-sort": patch
+"@jspsych/plugin-maxdiff": patch
 ---
 
-Remove uses of Array.from()
+Remove uses of Array.from() to improve Qualtrics compatibility

--- a/contributors.md
+++ b/contributors.md
@@ -34,6 +34,7 @@ The following people have contributed to the development of jsPsych by writing c
 * kupiqu - https://github.com/kupiqu
 * Daiichiro Kuroki - https://github.com/kurokida
 * Jonas Lambers
+* Max Lovell - https://github.com/max-lovell
 * madebyafox - https://github.com/madebyafox
 * Shane Martin - https://github.com/shamrt
 * Vijay Marupudi - https://github.com/vijaymarupudi

--- a/packages/jspsych/src/modules/plugin-api/KeyboardListenerAPI.ts
+++ b/packages/jspsych/src/modules/plugin-api/KeyboardListenerAPI.ts
@@ -48,7 +48,7 @@ export class KeyboardListenerAPI {
   private rootKeydownListener(e: KeyboardEvent) {
     // Iterate over a static copy of the listeners set because listeners might add other listeners
     // that we do not want to be included in the loop
-    for (const listener of Array.from(this.listeners)) {
+    for (const listener of [...this.listeners]) {
       listener(e);
     }
     this.heldKeys.add(this.toLowerCaseIfInsensitive(e.key));

--- a/packages/plugin-free-sort/src/index.ts
+++ b/packages/plugin-free-sort/src/index.ts
@@ -348,7 +348,7 @@ class FreeSortPlugin implements JsPsychPlugin<Info> {
     let cur_in = false;
 
     // draggable items
-    const draggables = Array.from(
+    const draggables = Array.prototype.slice.call(
       display_element.querySelectorAll<HTMLImageElement>(".jspsych-free-sort-draggable")
     );
 

--- a/packages/plugin-maxdiff/src/index.ts
+++ b/packages/plugin-maxdiff/src/index.ts
@@ -185,12 +185,12 @@ class MaxdiffPlugin implements JsPsychPlugin<Info> {
           // check response
           if (trial.required) {
             // Now check if one of both left and right have been enabled to allow submission
-            var left_checked = Array.from(document.getElementsByName("left")).some(
-              (c: HTMLInputElement) => c.checked
-            );
-            var right_checked = Array.from(document.getElementsByName("right")).some(
-              (c: HTMLInputElement) => c.checked
-            );
+            var left_checked = Array.prototype.slice
+              .call(document.getElementsByName("left"))
+              .some((c: HTMLInputElement) => c.checked);
+            var right_checked = Array.prototype.slice
+              .call(document.getElementsByName("right"))
+              .some((c: HTMLInputElement) => c.checked);
             if (left_checked && right_checked) {
               (document.getElementById("jspsych-maxdiff-next") as HTMLInputElement).disabled =
                 false;

--- a/packages/plugin-sketchpad/src/index.ts
+++ b/packages/plugin-sketchpad/src/index.ts
@@ -409,11 +409,11 @@ class SketchpadPlugin implements JsPsychPlugin<Info> {
       });
     }
 
-    this.sketchpad.addEventListener("pointerdown", this.start_draw);
-    this.sketchpad.addEventListener("pointermove", this.move_draw);
-    this.sketchpad.addEventListener("pointerup", this.end_draw);
-    this.sketchpad.addEventListener("pointerleave", this.end_draw);
-    this.sketchpad.addEventListener("pointercancel", this.end_draw);
+    this.sketchpad.addEventListener("pointerdown", this.start_draw.bind(this));
+    this.sketchpad.addEventListener("pointermove", this.move_draw.bind(this));
+    this.sketchpad.addEventListener("pointerup", this.end_draw.bind(this));
+    this.sketchpad.addEventListener("pointerleave", this.end_draw.bind(this));
+    this.sketchpad.addEventListener("pointercancel", this.end_draw.bind(this));
 
     if (this.params.key_to_draw !== null) {
       document.addEventListener("keydown", (e) => {
@@ -452,16 +452,22 @@ class SketchpadPlugin implements JsPsychPlugin<Info> {
     }
 
     if (this.params.show_undo_button) {
-      this.display.querySelector("#sketchpad-undo").addEventListener("click", this.undo);
+      this.display.querySelector("#sketchpad-undo").addEventListener("click", this.undo.bind(this));
       if (this.params.show_redo_button) {
-        this.display.querySelector("#sketchpad-redo").addEventListener("click", this.redo);
+        this.display
+          .querySelector("#sketchpad-redo")
+          .addEventListener("click", this.redo.bind(this));
       }
     }
     if (this.params.show_clear_button) {
-      this.display.querySelector("#sketchpad-clear").addEventListener("click", this.clear);
+      this.display
+        .querySelector("#sketchpad-clear")
+        .addEventListener("click", this.clear.bind(this));
     }
 
-    const color_btns = Array.from(this.display.querySelectorAll(".sketchpad-color-select"));
+    const color_btns = Array.prototype.slice.call(
+      this.display.querySelectorAll(".sketchpad-color-select")
+    );
     for (const btn of color_btns) {
       btn.addEventListener("click", (e) => {
         const target = e.target as HTMLButtonElement;


### PR DESCRIPTION
Qualtrics have overwritten/incorrectly polyfilled `Array.from()` such that it doesn't work, and so neither does jsPsych when run directly in Qualtrics. This PR then replaces uses of `Array.from()` in jsPsych with equivalent functions. So far, a wrapped spread operator `[...array]` is used in the KeyboardResponseAPI, and `Array.prototype.slice.call()` in the `maxdiff` and `free-sort` plugins. 

There's also a single `Array.from()` call in `packages/plugin-sketchpad/src/index.ts`, although I can't get this to run on my own fork even in the original version outside of Qualtrics. It also features heavily in the webgazer examples and demos.

Probably worth considering this doesn't do much for any extension, anything in contrib, or Survey-js etc, so Qualtrics compatibility isn't guaranteed, but atleast the core library can be used without dealing with an extra hosting site.

Follows from https://github.com/jspsych/jsPsych/discussions/3347.