### PR TITLE
Add eslint and stricter TypeScript rules for jspsych package

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,18 @@ export default tslint.config(
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          args: "all",
+          argsIgnorePattern: "^_",
+          caughtErrors: "all",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
+      ],
     },
   }
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,22 @@
+import eslint from "@eslint/js";
+import tslint from "typescript-eslint";
+
+export default tslint.config(
+  {
+    ignores: [
+      "docs/*",
+      "examples/*",
+      "packages/*",
+      "!packages/jspsych",
+      "packages/jspsych/*",
+      "!packages/jspsych/src",
+    ],
+  },
+  eslint.configs.recommended,
+  ...tslint.configs.recommended,
+  {
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,18 @@
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.7",
         "@changesets/cli": "^2.25.2",
+        "@eslint/js": "^9.9.1",
         "@jspsych/config": "^1.3.2",
+        "@types/eslint__js": "^8.42.3",
+        "eslint": "^9.9.1",
         "husky": "^8.0.2",
         "import-sort-style-module": "^6.0.0",
         "lint-staged": "^13.0.3",
         "prettier": "^2.7.1",
         "prettier-plugin-import-sort": "^0.0.7",
-        "turbo": "^1.6.3"
+        "turbo": "^1.6.3",
+        "typescript": "^5.5.4",
+        "typescript-eslint": "^8.3.0"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -2245,11 +2250,205 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
+      "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.4",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
+      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/@eslint/eslintrc/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.9.1.tgz",
+      "integrity": "sha512-xIDQRsfg5hNBqHz04H1R3scSVwmI+KUbqjsQKHKQ1DAUSaUjYPReZZmS/5PNiKu1fUvzDd6H7DEDKACSEhu+TQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
+      "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@fontsource/open-sans": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/@fontsource/open-sans/-/open-sans-4.5.3.tgz",
       "integrity": "sha512-zabYpvz2XkZ4Vp1EN2/k0r5X9kQgwjdj1+kJ6B0T/oN4h9yqJqr9VKxa+JspRxClxDEo23K5GqfuIEH1+WyFOw==",
       "dev": true
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.0.tgz",
+      "integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -3665,6 +3864,15 @@
         "@types/json-schema": "*"
       }
     },
+    "node_modules/@types/eslint__js": {
+      "version": "8.42.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint__js/-/eslint__js-8.42.3.tgz",
+      "integrity": "sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "*"
+      }
+    },
     "node_modules/@types/eslint-scope": {
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
@@ -3873,6 +4081,236 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.3.0.tgz",
+      "integrity": "sha512-FLAIn63G5KH+adZosDYiutqkOkYEx0nvcwNNfJAf+c7Ae/H35qWwTYvPZUKFj5AS+WfHG/WJJfWnDnyNUlp8UA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.3.0",
+        "@typescript-eslint/type-utils": "8.3.0",
+        "@typescript-eslint/utils": "8.3.0",
+        "@typescript-eslint/visitor-keys": "8.3.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.3.0.tgz",
+      "integrity": "sha512-h53RhVyLu6AtpUzVCYLPhZGL5jzTD9fZL+SYf/+hYOx2bDkyQXztXSc4tbvKYHzfMXExMLiL9CWqJmVz6+78IQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.3.0",
+        "@typescript-eslint/types": "8.3.0",
+        "@typescript-eslint/typescript-estree": "8.3.0",
+        "@typescript-eslint/visitor-keys": "8.3.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.3.0.tgz",
+      "integrity": "sha512-mz2X8WcN2nVu5Hodku+IR8GgCOl4C0G/Z1ruaWN4dgec64kDBabuXyPAr+/RgJtumv8EEkqIzf3X2U5DUKB2eg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.3.0",
+        "@typescript-eslint/visitor-keys": "8.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.3.0.tgz",
+      "integrity": "sha512-wrV6qh//nLbfXZQoj32EXKmwHf4b7L+xXLrP3FZ0GOUU72gSvLjeWUl5J5Ue5IwRxIV1TfF73j/eaBapxx99Lg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.3.0",
+        "@typescript-eslint/utils": "8.3.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.3.0.tgz",
+      "integrity": "sha512-y6sSEeK+facMaAyixM36dQ5NVXTnKWunfD1Ft4xraYqxP0lC0POJmIaL/mw72CUMqjY9qfyVfXafMeaUj0noWw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.3.0.tgz",
+      "integrity": "sha512-Mq7FTHl0R36EmWlCJWojIC1qn/ZWo2YiWYc1XVtasJ7FIgjo0MVv9rZWXEE7IK2CGrtwe1dVOxWwqXUdNgfRCA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.3.0",
+        "@typescript-eslint/visitor-keys": "8.3.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.3.0.tgz",
+      "integrity": "sha512-F77WwqxIi/qGkIGOGXNBLV7nykwfjLsdauRB/DOFPdv6LTF3BHHkBpq81/b5iMPSF055oO2BiivDJV4ChvNtXA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.3.0",
+        "@typescript-eslint/types": "8.3.0",
+        "@typescript-eslint/typescript-estree": "8.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.3.0.tgz",
+      "integrity": "sha512-RmZwrTbQ9QveF15m/Cl28n0LXD6ea2CjkhH5rQ55ewz3H24w+AMCJHPVYaZ8/0HoG8Z3cLLFFycRXxeO2tz9FA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.3.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
@@ -4078,9 +4516,9 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4104,6 +4542,15 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
@@ -6868,6 +7315,65 @@
         "source-map": "~0.6.1"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.9.1.tgz",
+      "integrity": "sha512-dHvhrbfr4xFQ9/dq+jcVneZMyRYLjggWjk6RVsIiHsP8Rz6yZ8LvZ//iU4TrZF+SXWG+JkNF2OyiZRvzgRDqMg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.11.0",
+        "@eslint/config-array": "^0.18.0",
+        "@eslint/eslintrc": "^3.1.0",
+        "@eslint/js": "9.9.1",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.3.0",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.0.2",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.1.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -6890,6 +7396,262 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-scope": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.2.tgz",
+      "integrity": "sha512-6E4xmrTw5wtxnLA5wYL3WDfhZ/1bUBGOXV0zQvVRDOtrR8D0p6W7fs3JweNYhwRYeGvd/1CKX2se0/2s7Q/nJA==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/esniff": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
@@ -6909,6 +7671,23 @@
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
       "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ=="
     },
+    "node_modules/espree": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
+      "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.12.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -6919,6 +7698,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/esrecurse": {
@@ -7277,9 +8068,9 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -7340,6 +8131,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -7639,6 +8442,25 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "dev": true
     },
     "node_modules/flow-parser": {
       "version": "0.237.2",
@@ -8344,6 +9166,12 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
+    },
     "node_modules/gulp": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
@@ -8793,9 +9621,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -9419,6 +10247,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -11760,6 +12597,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -11815,6 +12658,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz",
       "integrity": "sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ=="
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -12204,6 +13056,12 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "peer": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
@@ -13450,6 +14308,27 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module/node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -16238,6 +17117,12 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
     "node_modules/textextensions": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-3.3.0.tgz",
@@ -16482,6 +17367,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -16819,16 +17716,38 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
-      "peer": true,
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.3.0.tgz",
+      "integrity": "sha512-EvWjwWLwwKDIJuBjk2I6UkV8KEQcwZ0VM10nR1rIunRDIP67QJTZAHBXTX0HW/oI1H10YESF8yWie8fRQxjvFA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.3.0",
+        "@typescript-eslint/parser": "8.3.0",
+        "@typescript-eslint/utils": "8.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/unbox-primitive": {
@@ -18093,18 +19012,6 @@
         "@rollup/rollup-win32-ia32-msvc": "4.3.0",
         "@rollup/rollup-win32-x64-msvc": "4.3.0",
         "fsevents": "~2.3.2"
-      }
-    },
-    "packages/config/node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/extension-mouse-tracking": {

--- a/package.json
+++ b/package.json
@@ -27,13 +27,18 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.7",
     "@changesets/cli": "^2.25.2",
+    "@eslint/js": "^9.9.1",
     "@jspsych/config": "^1.3.2",
+    "@types/eslint__js": "^8.42.3",
+    "eslint": "^9.9.1",
     "husky": "^8.0.2",
     "import-sort-style-module": "^6.0.0",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
     "prettier-plugin-import-sort": "^0.0.7",
-    "turbo": "^1.6.3"
+    "turbo": "^1.6.3",
+    "typescript": "^5.5.4",
+    "typescript-eslint": "^8.3.0"
   },
   "prettier": {
     "printWidth": 100

--- a/packages/jspsych/package.json
+++ b/packages/jspsych/package.json
@@ -28,7 +28,7 @@
     "build": "run-p build:js build:styles",
     "build:watch": "run-p \"build:js -- --watch\" \"build:styles watch\"",
     "prepack": "cp ../../README.md .",
-    "lint": "eslint src"
+    "lint": "tsc --noEmit && eslint src"
   },
   "repository": {
     "type": "git",

--- a/packages/jspsych/package.json
+++ b/packages/jspsych/package.json
@@ -27,7 +27,8 @@
     "build:styles": "webpack-cli",
     "build": "run-p build:js build:styles",
     "build:watch": "run-p \"build:js -- --watch\" \"build:styles watch\"",
-    "prepack": "cp ../../README.md ."
+    "prepack": "cp ../../README.md .",
+    "lint": "eslint src"
   },
   "repository": {
     "type": "git",

--- a/packages/jspsych/src/ProgressBar.spec.ts
+++ b/packages/jspsych/src/ProgressBar.spec.ts
@@ -49,7 +49,7 @@ describe("ProgressBar", () => {
       // Override default container element and progress bar
       containerElement = document.createElement("div");
       progressBar = new ProgressBar(containerElement, (progress: number) => String(progress));
-      let messageSpan: HTMLSpanElement = containerElement.querySelector("span");
+      const messageSpan: HTMLSpanElement = containerElement.querySelector("span");
 
       expect(messageSpan.innerHTML).toEqual("0");
 

--- a/packages/jspsych/src/ProgressBar.spec.ts
+++ b/packages/jspsych/src/ProgressBar.spec.ts
@@ -30,7 +30,7 @@ describe("ProgressBar", () => {
 
     it("errors if an invalid progress value is provided", () => {
       expect(() => {
-        // @ts-expect-error
+        // @ts-expect-error - progressBar.progress is typed as a a number, but should handle the case of a string
         progressBar.progress = "0";
       }).toThrowErrorMatchingInlineSnapshot(
         '"jsPsych.progressBar.progress must be a number between 0 and 1"'

--- a/packages/jspsych/src/index.ts
+++ b/packages/jspsych/src/index.ts
@@ -3,17 +3,6 @@
 import { JsPsych } from "./JsPsych";
 import { MigrationError } from "./migration";
 
-// temporary patch for Safari
-if (
-  typeof window !== "undefined" &&
-  Object.hasOwn(window, "webkitAudioContext") &&
-  !Object.hasOwn(window, "AudioContext")
-) {
-  // @ts-expect-error
-  window.AudioContext = webkitAudioContext;
-}
-// end patch
-
 // The following function provides a uniform interface to initialize jsPsych, no matter whether a
 // browser supports ES6 classes or not (and whether the ES6 build or the Babel build is used).
 /**

--- a/packages/jspsych/src/index.ts
+++ b/packages/jspsych/src/index.ts
@@ -6,8 +6,8 @@ import { MigrationError } from "./migration";
 // temporary patch for Safari
 if (
   typeof window !== "undefined" &&
-  window.hasOwnProperty("webkitAudioContext") &&
-  !window.hasOwnProperty("AudioContext")
+  Object.hasOwn(window, "webkitAudioContext") &&
+  !Object.hasOwn(window, "AudioContext")
 ) {
   // @ts-expect-error
   window.AudioContext = webkitAudioContext;

--- a/packages/jspsych/src/modules/data/index.ts
+++ b/packages/jspsych/src/modules/data/index.ts
@@ -127,11 +127,11 @@ export class JsPsychData {
     },
     fullscreenchange: () => {
       this.addInteractionRecord(
-        // @ts-expect-error
+        // @ts-expect-error - legacy code
         document.isFullScreen ||
-          // @ts-expect-error
+          // @ts-expect-error - legacy code
           document.webkitIsFullScreen ||
-          // @ts-expect-error
+          // @ts-expect-error - legacy code
           document.mozIsFullScreen ||
           document.fullscreenElement
           ? "fullscreenenter"

--- a/packages/jspsych/src/modules/plugin-api/MediaAPI.ts
+++ b/packages/jspsych/src/modules/plugin-api/MediaAPI.ts
@@ -9,6 +9,9 @@ const preloadParameterTypes = <const>[
 ];
 type PreloadType = typeof preloadParameterTypes[number];
 
+type CallbackLoad = (filepath: string) => void;
+type CallbackError = (callback_error: any) => void;
+
 export class MediaAPI {
   constructor(public useWebaudio: boolean) {
     if (
@@ -61,8 +64,8 @@ export class MediaAPI {
   preloadAudio(
     files,
     callback_complete = () => {},
-    callback_load = (filepath: string) => {},
-    callback_error = (error) => {}
+    callback_load: CallbackLoad = () => {},
+    callback_error: CallbackError = () => {}
   ) {
     files = unique(files.flat());
 
@@ -105,8 +108,8 @@ export class MediaAPI {
   preloadImages(
     images,
     callback_complete = () => {},
-    callback_load = (filepath) => {},
-    callback_error = (error_msg) => {}
+    callback_load: CallbackLoad = () => {},
+    callback_error: CallbackError = () => {}
   ) {
     // flatten the images array
     images = unique(images.flat());
@@ -143,8 +146,8 @@ export class MediaAPI {
   preloadVideo(
     videos,
     callback_complete = () => {},
-    callback_load = (filepath) => {},
-    callback_error = (error_msg) => {}
+    callback_load: CallbackLoad = () => {},
+    callback_error: CallbackError = () => {}
   ) {
     // flatten the video array
     videos = unique(videos.flat());
@@ -181,7 +184,7 @@ export class MediaAPI {
         }
         callback_error({ source: video, error: err });
       };
-      request.onloadend = (e) => {
+      request.onloadend = () => {
         if (request.status == 404) {
           callback_error({ source: video, error: "404" });
         }

--- a/packages/jspsych/src/modules/plugin-api/MediaAPI.ts
+++ b/packages/jspsych/src/modules/plugin-api/MediaAPI.ts
@@ -114,7 +114,7 @@ export class MediaAPI {
     // flatten the images array
     images = unique(images.flat());
 
-    var n_loaded = 0;
+    let n_loaded = 0;
 
     if (images.length === 0) {
       callback_complete();

--- a/packages/jspsych/src/modules/plugin-api/__mocks__/AudioPlayer.ts
+++ b/packages/jspsych/src/modules/plugin-api/__mocks__/AudioPlayer.ts
@@ -3,7 +3,7 @@ const actual = jest.requireActual("../AudioPlayer");
 export const mockStop = jest.fn();
 
 export const AudioPlayer = jest.fn().mockImplementation(() => {
-  let eventHandlers = {};
+  const eventHandlers = {};
 
   const mockInstance = Object.create(actual.AudioPlayer.prototype);
 

--- a/packages/jspsych/src/modules/plugin-api/__mocks__/AudioPlayer.ts
+++ b/packages/jspsych/src/modules/plugin-api/__mocks__/AudioPlayer.ts
@@ -1,38 +1,34 @@
-import { AudioPlayerOptions } from "../AudioPlayer";
-
 const actual = jest.requireActual("../AudioPlayer");
 
 export const mockStop = jest.fn();
 
-export const AudioPlayer = jest
-  .fn()
-  .mockImplementation((src: string, options: AudioPlayerOptions = { useWebAudio: false }) => {
-    let eventHandlers = {};
+export const AudioPlayer = jest.fn().mockImplementation(() => {
+  let eventHandlers = {};
 
-    const mockInstance = Object.create(actual.AudioPlayer.prototype);
+  const mockInstance = Object.create(actual.AudioPlayer.prototype);
 
-    return Object.assign(mockInstance, {
-      load: jest.fn(),
-      play: jest.fn(() => {
-        setTimeout(() => {
-          if (eventHandlers["ended"]) {
-            for (const handler of eventHandlers["ended"]) {
-              handler();
-            }
+  return Object.assign(mockInstance, {
+    load: jest.fn(),
+    play: jest.fn(() => {
+      setTimeout(() => {
+        if (eventHandlers["ended"]) {
+          for (const handler of eventHandlers["ended"]) {
+            handler();
           }
-        }, 1000);
-      }),
-      stop: mockStop,
-      addEventListener: jest.fn((event, handler) => {
-        if (!eventHandlers[event]) {
-          eventHandlers[event] = [];
         }
-        eventHandlers[event].push(handler);
-      }),
-      removeEventListener: jest.fn((event, handler) => {
-        if (eventHandlers[event] === handler) {
-          eventHandlers[event] = eventHandlers[event].filter((h) => h !== handler);
-        }
-      }),
-    });
+      }, 1000);
+    }),
+    stop: mockStop,
+    addEventListener: jest.fn((event, handler) => {
+      if (!eventHandlers[event]) {
+        eventHandlers[event] = [];
+      }
+      eventHandlers[event].push(handler);
+    }),
+    removeEventListener: jest.fn((event, handler) => {
+      if (eventHandlers[event] === handler) {
+        eventHandlers[event] = eventHandlers[event].filter((h) => h !== handler);
+      }
+    }),
   });
+});

--- a/packages/jspsych/src/modules/randomization.ts
+++ b/packages/jspsych/src/modules/randomization.ts
@@ -31,7 +31,7 @@ export function repeat(array: any, repetitions: any, unpack = false) {
     // if repetitions is not an array, but array is, then we
     // repeat repetitions for each entry in array
     if (!rep_isArray) {
-      let reps = [];
+      const reps = [];
       for (let i = 0; i < array.length; i++) {
         reps.push(repetitions);
       }
@@ -43,7 +43,7 @@ export function repeat(array: any, repetitions: any, unpack = false) {
         );
         // throw warning if repetitions is too short, use first rep ONLY.
         if (repetitions.length < array.length) {
-          let reps = [];
+          const reps = [];
           for (let i = 0; i < array.length; i++) {
             reps.push(repetitions);
           }
@@ -57,7 +57,7 @@ export function repeat(array: any, repetitions: any, unpack = false) {
   }
 
   // should be clear at this point to assume that array and repetitions are arrays with == length
-  let allsamples = [];
+  const allsamples = [];
   for (let i = 0; i < array.length; i++) {
     for (let j = 0; j < repetitions[i]; j++) {
       if (array[i] == null || typeof array[i] != "object") {
@@ -337,8 +337,8 @@ export function randomWords<T extends RandomWordsOptions>(opts: T) {
 // Box-Muller transformation for a random sample from normal distribution with mean = 0, std = 1
 // https://stackoverflow.com/a/36481059/3726673
 function randn_bm() {
-  var u = 0,
-    v = 0;
+  let u = 0;
+  let v = 0;
   while (u === 0) u = Math.random(); //Converting [0,1) to (0,1)
   while (v === 0) v = Math.random();
   return Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);

--- a/packages/jspsych/src/modules/turk.ts
+++ b/packages/jspsych/src/modules/turk.ts
@@ -41,7 +41,7 @@ export function turkInfo(): turkInformation {
   };
 
   const param = function (url, name) {
-    name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+    name = name.replace(/[[]/, "\\[").replace(/[\]]/, "\\]");
     const regexS = "[\\?&]" + name + "=([^&#]*)";
     const regex = new RegExp(regexS);
     const results = regex.exec(url);

--- a/packages/jspsych/src/modules/turk.ts
+++ b/packages/jspsych/src/modules/turk.ts
@@ -83,7 +83,7 @@ export function submitToTurk(data) {
   form.action = turkSubmitTo + "/mturk/externalSubmit?assignmentId=" + assignmentId;
 
   for (const key in data) {
-    if (data.hasOwnProperty(key)) {
+    if (Object.hasOwn(data, key)) {
       const hiddenField = document.createElement("input");
       hiddenField.type = "hidden";
       hiddenField.name = key;

--- a/packages/jspsych/src/modules/utils.ts
+++ b/packages/jspsych/src/modules/utils.ts
@@ -19,7 +19,7 @@ export function deepCopy(obj) {
   } else if (typeof obj === "object" && obj !== null) {
     out = {};
     for (const key in obj) {
-      if (obj.hasOwnProperty(key)) {
+      if (Object.hasOwn(obj, key)) {
         out[key] = deepCopy(obj[key]);
       }
     }
@@ -37,8 +37,8 @@ export function deepCopy(obj) {
 export function deepMerge(obj1: any, obj2: any): any {
   const merged = {};
   for (const key in obj1) {
-    if (obj1.hasOwnProperty(key)) {
-      if (typeof obj1[key] === "object" && obj2.hasOwnProperty(key)) {
+    if (Object.hasOwn(obj1, key)) {
+      if (typeof obj1[key] === "object" && Object.hasOwn(obj2, key)) {
         merged[key] = deepMerge(obj1[key], obj2[key]);
       } else {
         merged[key] = obj1[key];
@@ -46,8 +46,8 @@ export function deepMerge(obj1: any, obj2: any): any {
     }
   }
   for (const key in obj2) {
-    if (obj2.hasOwnProperty(key)) {
-      if (!merged.hasOwnProperty(key)) {
+    if (Object.hasOwn(obj2, key)) {
+      if (!Object.hasOwn(merged, key)) {
         merged[key] = obj2[key];
       } else if (typeof obj2[key] === "object") {
         merged[key] = deepMerge(merged[key], obj2[key]);

--- a/packages/jspsych/src/modules/utils.ts
+++ b/packages/jspsych/src/modules/utils.ts
@@ -35,7 +35,7 @@ export function deepCopy(obj) {
  * @param obj2 Object to merge
  */
 export function deepMerge(obj1: any, obj2: any): any {
-  let merged = {};
+  const merged = {};
   for (const key in obj1) {
     if (obj1.hasOwnProperty(key)) {
       if (typeof obj1[key] === "object" && obj2.hasOwnProperty(key)) {

--- a/packages/jspsych/src/timeline/Timeline.ts
+++ b/packages/jspsych/src/timeline/Timeline.ts
@@ -231,7 +231,10 @@ export class Timeline extends TimelineNode {
   }
 
   public evaluateTimelineVariable(variable: TimelineVariable) {
-    if (this.currentTimelineVariables?.hasOwnProperty(variable.name)) {
+    if (
+      this.currentTimelineVariables &&
+      Object.hasOwn(this.currentTimelineVariables, variable.name)
+    ) {
       return this.currentTimelineVariables[variable.name];
     }
     throw new Error(`Timeline variable ${variable.name} not found.`);

--- a/packages/jspsych/src/timeline/TimelineNode.ts
+++ b/packages/jspsych/src/timeline/TimelineNode.ts
@@ -131,7 +131,8 @@ export abstract class TimelineNode {
       parameterPath = [parameterPath];
     }
 
-    let { doesPathExist, value: result } = this.parameterValueCache.lookup(parameterPath);
+    const { doesPathExist, value } = this.parameterValueCache.lookup(parameterPath);
+    let result = value;
     if (!doesPathExist && recursive && this.parent) {
       result = this.parent.getParameterValue(parameterPath, options);
     }

--- a/packages/jspsych/src/timeline/Trial.spec.ts
+++ b/packages/jspsych/src/timeline/Trial.spec.ts
@@ -106,7 +106,7 @@ describe("Trial", () => {
         await trial1.run();
         expect(trial1.getResult()).toEqual(expect.objectContaining({ my: "result" }));
 
-        TestPlugin.trial = async (display_element, trial, on_load) => {
+        TestPlugin.trial = async (_display_element, _trial, on_load) => {
           on_load();
           dependencies.finishTrialPromise.resolve({ finishTrial: "result" });
           return { my: "result" };

--- a/packages/jspsych/src/timeline/Trial.ts
+++ b/packages/jspsych/src/timeline/Trial.ts
@@ -410,7 +410,7 @@ export class Trial extends TimelineNode {
     return this;
   }
 
-  public getActiveTimelineByName(name: string): Timeline | undefined {
+  public getActiveTimelineByName(_name: string): Timeline | undefined {
     // This returns undefined because the function is looking
     // for a timeline. If we get to this point, then none
     // of the parent nodes match the name.

--- a/packages/jspsych/tests/TestPlugin.ts
+++ b/packages/jspsych/tests/TestPlugin.ts
@@ -1,5 +1,5 @@
 import { flushPromises } from "@jspsych/test-utils";
-import { JsPsych, JsPsychPlugin, TrialType } from "jspsych";
+import { JsPsychPlugin, TrialType } from "jspsych";
 
 import { ParameterInfos } from "../src/modules/plugins";
 import { SimulationMode, SimulationOptions, TrialResult } from "../src/timeline";
@@ -88,7 +88,7 @@ class TestPlugin implements JsPsychPlugin<typeof testPluginInfo> {
     TestPlugin.setImmediateFinishTrialMode();
   }
 
-  constructor(private jsPsych: JsPsych) {}
+  constructor() {}
 
   trial = jest.fn(TestPlugin.trial);
   simulate = jest.fn(TestPlugin.simulate);

--- a/packages/jspsych/tests/core/simulation-mode.test.ts
+++ b/packages/jspsych/tests/core/simulation-mode.test.ts
@@ -193,8 +193,6 @@ describe("data simulation mode", () => {
   });
 
   test("Simulation options can be a function that evals at run time", async () => {
-    const jsPsych = initJsPsych();
-
     const timeline = [
       {
         type: htmlKeyboardResponse,
@@ -217,8 +215,6 @@ describe("data simulation mode", () => {
   });
 
   test("Simulation options can be a function that evals to a string at run time", async () => {
-    const jsPsych = initJsPsych();
-
     const timeline = [
       {
         type: htmlKeyboardResponse,
@@ -265,8 +261,6 @@ describe("data simulation mode", () => {
         });
       }
     }
-
-    const jsPsych = initJsPsych();
 
     const timeline = [
       {
@@ -470,13 +464,9 @@ describe("data simulation mode", () => {
       },
     ];
 
-    const { jsPsych, expectRunning, expectFinished, getData } = await simulateTimeline(
-      timeline,
-      "visual",
-      {
-        default: { data: { rt: 200 } },
-      }
-    );
+    const { expectFinished, getData } = await simulateTimeline(timeline, "visual", {
+      default: { data: { rt: 200 } },
+    });
 
     // Make the event loop tick for each simulated keyboard response
     jest.runAllTimers();

--- a/packages/jspsych/tests/core/timeline-variables.test.ts
+++ b/packages/jspsych/tests/core/timeline-variables.test.ts
@@ -89,7 +89,7 @@ describe("sampling", () => {
 
   test("fixed repetitions method produces random order", async () => {
     const jsPsych = initJsPsych();
-    const seed = jsPsych.randomization.setSeed("jspsych");
+    jsPsych.randomization.setSeed("jspsych");
 
     const { expectFinished } = await startTimeline(
       [

--- a/packages/jspsych/tests/data/datamodule.test.ts
+++ b/packages/jspsych/tests/data/datamodule.test.ts
@@ -122,11 +122,6 @@ describe("#displayData", () => {
 
     // click through first trial
     await pressKey("a");
-    // overwrite data with custom data
-    const data = [
-      { col1: 1, col2: 2 },
-      { col1: 3, col2: 4 },
-    ];
     // display data in json format
     jsPsych.data.displayData("csv");
     // check display element HTML

--- a/packages/jspsych/tests/extensions/test-extension.ts
+++ b/packages/jspsych/tests/extensions/test-extension.ts
@@ -1,4 +1,4 @@
-import { JsPsych, JsPsychExtension } from "../../src";
+import { JsPsychExtension } from "../../src";
 
 export class TestExtension implements JsPsychExtension {
   static info = {
@@ -7,7 +7,7 @@ export class TestExtension implements JsPsychExtension {
     data: {},
   };
 
-  constructor(private jsPsych: JsPsych) {}
+  constructor() {}
 
   // required, will be called at initJsPsych
   // should return a Promise

--- a/packages/jspsych/tests/pluginAPI/pluginapi.test.ts
+++ b/packages/jspsych/tests/pluginAPI/pluginapi.test.ts
@@ -190,12 +190,12 @@ describe("#getKeyboardResponse", () => {
     const callback_1 = jest.fn();
     const callback_2 = jest.fn();
     const api = new KeyboardListenerAPI(getRootElement);
-    const listener_1 = api.getKeyboardResponse({
+    api.getKeyboardResponse({
       callback_function: callback_1,
       valid_responses: ["a"],
       persist: true,
     });
-    const listener_2 = api.getKeyboardResponse({
+    api.getKeyboardResponse({
       callback_function: callback_2,
       persist: false,
     });

--- a/packages/jspsych/tsconfig.json
+++ b/packages/jspsych/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@jspsych/config/tsconfig.core.json",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "noUnusedLocals": true
   },
   "include": ["src", "tests", "package.json"]
 }

--- a/packages/plugin-instructions/src/index.ts
+++ b/packages/plugin-instructions/src/index.ts
@@ -1,5 +1,4 @@
 import { JsPsych, JsPsychPlugin, ParameterType, TrialType } from "jspsych";
-import { parameterPathArrayToString } from "jspsych/src/timeline/util";
 
 import { version } from "../package.json";
 

--- a/packages/plugin-reconstruction/src/index.ts
+++ b/packages/plugin-reconstruction/src/index.ts
@@ -1,5 +1,4 @@
 import { JsPsych, JsPsychPlugin, ParameterType, TrialType } from "jspsych";
-import { parameterPathArrayToString } from "jspsych/src/timeline/util";
 
 import { version } from "../package.json";
 


### PR DESCRIPTION
I am planning to add the option to use camel case variables to the jspsych (see issue https://github.com/jspsych/jsPsych/issues/3386). To make sure this doesn't break any existing functionality, I think it would be a good idea to enable TypeScript strict mode (I also see this is something you want on a "lucky day"). Well, it is a lucky day!

I propose to do this in stages, each adding one of the strict rules (until finally `strictNullChecks`, which is the really difficult one here). I also added eslint (only for the jspsych package) to help with some additional best practices checking. 

This PR makes changes that bring the existing code into compliance with the standard TypeScript linting rules and `noUnusedLocales` TypeScript rules. 

I also removed the `AudioContext` hack for Safari, as it looks like `AudioContext` has been supported in Safari for a number of years now. If this is not okay, let me know I can add it back.