### PR TITLE
let contrib repo import json files as modules

### DIFF
--- a/.changeset/eight-steaks-camp.md
+++ b/.changeset/eight-steaks-camp.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/config": patch
+---
+
+allow JSON resolution in contrib repository for usage of package.json in versioning

--- a/packages/config/tsconfig.contrib.json
+++ b/packages/config/tsconfig.contrib.json
@@ -6,7 +6,5 @@
       // map jspsych-contrib package imports directly to their source files
       "@jspsych-contrib/*": ["../*/src"]
     },
-    // allow json resolving to automatically pull package.json info
-    "resolveJsonModule": true
   }
 }

--- a/packages/config/tsconfig.contrib.json
+++ b/packages/config/tsconfig.contrib.json
@@ -5,6 +5,8 @@
     "paths": {
       // map jspsych-contrib package imports directly to their source files
       "@jspsych-contrib/*": ["../*/src"]
-    }
+    },
+    // allow json resolving to automatically pull package.json info
+    "resolveJsonModule": true
   }
 }

--- a/packages/config/tsconfig.core.json
+++ b/packages/config/tsconfig.core.json
@@ -7,7 +7,5 @@
       "jspsych": ["../jspsych/src"],
       "@jspsych/*": ["../*/src"]
     },
-    // allow resolving json modules in tests (needed for transitive imports of jspsych)
-    "resolveJsonModule": true
   }
 }

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -17,7 +17,6 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "isolatedModules": true, // required by Sucrase
-    // required for automatic package versioning and needed for transitive imports of jspsych)
-    "resolveJsonModule": true,
+    "resolveJsonModule": true, // required for automatic package versioning and needed for transitive imports of jspsych
   }
 }

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -16,6 +16,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
-    "isolatedModules": true // required by Sucrase
+    "isolatedModules": true, // required by Sucrase
+    // required for automatic package versioning and needed for transitive imports of jspsych)
+    "resolveJsonModule": true,
   }
 }


### PR DESCRIPTION
this pr allows for the contrib repo to import JSON files as modules. this is to give contrib plugins the ability to pull the version directly from `package.json` and into their plugin info fields, similarly to how it is done in the main repo.