### PR TITLE
Update jspsych-extension-mouse-tracking.html

### DIFF
--- a/examples/jspsych-extension-mouse-tracking.html
+++ b/examples/jspsych-extension-mouse-tracking.html
@@ -82,13 +82,8 @@
       return true;
     }
   };
-
-  if (typeof jsPsych !== "undefined") {
-    jsPsych.run([trial_loop]);
-  } else {
-    document.body.innerHTML = '<div style="text-align:center; margin-top:50%; transform:translate(0,-50%);">You must be online to view the plugin demo.</div>';
-  }
-
+  
+  jsPsych.run([trial_loop]);
 </script>
 
 </html>

--- a/examples/jspsych-extension-mouse-tracking.html
+++ b/examples/jspsych-extension-mouse-tracking.html
@@ -84,7 +84,7 @@
   };
 
   if (typeof jsPsych !== "undefined") {
-    jsPsych.run([start, trial_loop]);
+    jsPsych.run([trial_loop]);
   } else {
     document.body.innerHTML = '<div style="text-align:center; margin-top:50%; transform:translate(0,-50%);">You must be online to view the plugin demo.</div>';
   }


### PR DESCRIPTION
The const `start` has been removed in the previous commit, and does not seem to be currently required to run the demo (i.e., the reference to it raises "Uncaught ReferenceError:".