### PR TITLE
Add test case for #3412

### DIFF
--- a/packages/jspsych/src/timeline/Trial.spec.ts
+++ b/packages/jspsych/src/timeline/Trial.spec.ts
@@ -387,6 +387,7 @@ describe("Trial", () => {
 
         // This should work:
         await createTrial({ type: TestPlugin, stringArray: [] }).run();
+        await createTrial({ type: TestPlugin, stringArray: new TimelineVariable("a") });
 
         // This shouldn't:
         await expect(
@@ -436,6 +437,8 @@ describe("Trial", () => {
                 return TestPlugin;
               case "x":
                 return "foo";
+              case "y":
+                return ["foo", "bar"];
               default:
                 return undefined;
             }
@@ -444,17 +447,19 @@ describe("Trial", () => {
         const trial = createTrial({
           type: new TimelineVariable("t"),
           requiredString: new TimelineVariable("x"),
+          stringArray: new TimelineVariable("y"),
           requiredComplexNested: { requiredChild: () => new TimelineVariable("x") },
           requiredComplexNestedArray: [{ requiredChild: () => new TimelineVariable("x") }],
         });
 
         await trial.run();
 
-        // The `x` timeline variables should have been replaced with `foo`
+        // The `x` and `y` timeline variables should have been evaluated
         expect(trial.pluginInstance.trial).toHaveBeenCalledWith(
           expect.anything(),
           expect.objectContaining({
             requiredString: "foo",
+            stringArray: ["foo", "bar"],
             requiredComplexNested: expect.objectContaining({ requiredChild: "foo" }),
             requiredComplexNestedArray: [expect.objectContaining({ requiredChild: "foo" })],
           }),


### PR DESCRIPTION
#3412 gives the impression that jsPsych rejects timeline variables for array plugin parameters. This PR extens a test case for this, showing that timeline variable evaluation works as expected for array parameters.
