### PR TITLE
Respect dynamically added trial/timeline descriptions

### DIFF
--- a/.changeset/large-plums-guess.md
+++ b/.changeset/large-plums-guess.md
@@ -1,0 +1,5 @@
+---
+"jspsych": minor
+---
+
+We added a feature that allows users to dynamically add or remove trials or nested timelines to a timeline array during runtime.

--- a/docs/overview/timeline.md
+++ b/docs/overview/timeline.md
@@ -586,7 +586,7 @@ main_timeline.push(part1_trial, choice_trial);
 ```
 In the above implementation of `choice_trial`, choice 1 adds `english_branch` at the start of `main_timeline`, such that `main_timeline = [english_branch, part1_trial, choice_trial]`, but because the execution of `main_timeline` is past the first node at this point in runtime, the newly added `english_branch` will not be executed. Similarly, modifying `case '1'` in `choice_trial` to remove `part1_trial` will not change any behavior in the timeline.
 
-!!! danger "Dynamically adding/removing nodes in a  looping timeline"
+!!! danger
 In the case of a looping timeline, adding a timeline node at a point before the current node will cause the current node to be executed again; and removing a timeline node at a point before the current node will cause the next node to be skipped.
 
 ## Timeline start and finish functions

--- a/docs/overview/timeline.md
+++ b/docs/overview/timeline.md
@@ -1,24 +1,3 @@
-- [Creating an Experiment: The Timeline](#creating-an-experiment-the-timeline)
-	- [A single trial](#a-single-trial)
-	- [Multiple trials](#multiple-trials)
-	- [Nested timelines](#nested-timelines)
-	- [Timeline variables](#timeline-variables)
-		- [Using timeline variables in a function](#using-timeline-variables-in-a-function)
-		- [Random orders of trials](#random-orders-of-trials)
-		- [Sampling methods](#sampling-methods)
-			- [Sampling with replacement](#sampling-with-replacement)
-			- [Sampling with replacement, unequal probabilities](#sampling-with-replacement-unequal-probabilities)
-			- [Sampling without replacement](#sampling-without-replacement)
-			- [Repeating each trial a fixed number of times in a random order](#repeating-each-trial-a-fixed-number-of-times-in-a-random-order)
-			- [Alternating groups](#alternating-groups)
-			- [Custom sampling function](#custom-sampling-function)
-	- [Repeating a set of trials](#repeating-a-set-of-trials)
-	- [Looping timelines](#looping-timelines)
-	- [Conditional timelines](#conditional-timelines)
-	- [Modifying timelines at runtime](#modifying-timelines-at-runtime)
-		- [Exception cases for adding/removing timeline nodes dynamically](#exception-cases-for-addingremoving-timeline-nodes-dynamically)
-	- [Timeline start and finish functions](#timeline-start-and-finish-functions)
-  
 # Creating an Experiment: The Timeline
 
 To create an experiment using jsPsych, you need to specify a timeline that describes the structure of the experiment. The timeline is an ordered set of trials. You must create the timeline before launching the experiment. Most of the code you will write for an experiment will be code to create the timeline. This page walks through the creation of timelines, including very basic examples and more advanced features.

--- a/docs/overview/timeline.md
+++ b/docs/overview/timeline.md
@@ -504,7 +504,7 @@ const branch_3 = [b3_t1, b3_t2, b3_t3];
 
 const choice_trial = {
 	type: jsPsychHtmlKeyboardResponse,
-	stimulus: 'Press 1 if you are a new participant. Press 2 for inquiries about an existing experiment run. Press 3 for Spanish.',
+	stimulus: 'Press 1 for English. Press 2 for Mandarin. Press 3 for Spanish.',
 	choices: ['1','2','3'],
 	on_finish: (data) => {
 		switch(data.response) {
@@ -531,7 +531,7 @@ You can also remove upcoming timeline nodes from the timeline at runtime. To dem
 ```javascript
 const choice_trial = {
 	type: jsPsychHtmlKeyboardResponse,
-	stimulus: 'Press 1 if you are a new participant. Press 2 for inquiries about an existing experiment run. Press 3 for Spanish. Press 4 to exit.',
+	stimulus: 'Press 1 for English. Press 2 for Mandarin. Press 3 for Spanish. Press 4 to exit.',
 	choices: ['1','2','3', '4'],
 	on_finish: (data) => {
 		switch(data.response) {

--- a/docs/overview/timeline.md
+++ b/docs/overview/timeline.md
@@ -469,9 +469,9 @@ jsPsych.run([pre_if_trial, if_node, after_if_trial]);
 
 ## Modifying timelines at runtime
 
-Although this functionality can also be achieved through a combination of the `conditional_function` and the use of dynamic variables in the `stimulus` parameter, our timeline implementation allows you to dynamically insert or remove trials and nested timelines during runtime.
+Although this functionality can also be achieved through a combination of the `conditional_function` and the use of dynamic variables in the `stimulus` parameter, our timeline implementation allows you to dynamically add or remove trials and nested timelines during runtime.
 
-### Inserting timeline nodes at runtime
+### Adding timeline nodes at runtime
 For example, you may have a branching point in your experiment where the participant is given 3 choices, each leading to a different timeline: 
 
 ```javascript
@@ -564,7 +564,7 @@ main_timeline.push(part1_trial, choice_trial, part2_timeline)
 Now, if 1, 2 or 3 were chosen during runtime, `part2_timeline` will run after the dynamically added timeline corresponding to the choice (`english_branch` | `mandarin_branch` | `spanish_branch`) has been run; but if 4 was chosen, `part2_timeline` will be removed at runtime, and `main_timeline` will terminate.
 
 ### Exception cases for adding/removing timeline nodes dynamically
-Adding or removing timeline nodes work as expected when the addition/removal occurs at a future point in the timeline relative to the current executing node, but not if it occurs before the current node. The example above works as expected becaues all the node(s) added (`english_branch` | `mandarin_branch` | `spanish_branch`) or removed (`part2_timeline`) occur at the end of the timeline via `push()` and `pop()`. If a node was inserted at a point in the timeline that has already been executed, it will not be executed:
+Adding or removing timeline nodes work as expected when the addition/removal occurs at a future point in the timeline relative to the current executing node, but not if it occurs before the current node. The example above works as expected becaues all the node(s) added (`english_branch` | `mandarin_branch` | `spanish_branch`) or removed (`part2_timeline`) occur at the end of the timeline via `push()` and `pop()`. If a node was added at a point in the timeline that has already been executed, it will not be executed:
 
 ```javascript
 const choice_trial = {
@@ -584,9 +584,10 @@ const choice_trial = {
 
 main_timeline.push(part1_trial, choice_trial);
 ```
-In the above implementation of `choice_trial`, choice 1 adds `english_branch` to the start of `main_timeline`, such that `main_timeline = [english_branch, part1_trial, choice_trial]`, but because the execution of `main_timeline` is past the first node at this point in runtime, the newly added `english_branch` will not be executed. Similarly, modifying `case '1'` in `choice_trial` to remove `part1_trial` will not change any behavior in the timeline.
+In the above implementation of `choice_trial`, choice 1 adds `english_branch` at the start of `main_timeline`, such that `main_timeline = [english_branch, part1_trial, choice_trial]`, but because the execution of `main_timeline` is past the first node at this point in runtime, the newly added `english_branch` will not be executed. Similarly, modifying `case '1'` in `choice_trial` to remove `part1_trial` will not change any behavior in the timeline.
 
-<strong>DON'T DO THIS:</strong> In the case of a looping timeline, adding a timeline node at a point before the current node will cause the current node to be executed again; and removing a timeline node at a point before the current node will cause the next node to be skipped.
+!!! danger "Dynamically adding/removing nodes in a  looping timeline"
+In the case of a looping timeline, adding a timeline node at a point before the current node will cause the current node to be executed again; and removing a timeline node at a point before the current node will cause the next node to be skipped.
 
 ## Timeline start and finish functions
 

--- a/packages/jspsych/src/timeline/Timeline.spec.ts
+++ b/packages/jspsych/src/timeline/Timeline.spec.ts
@@ -75,6 +75,72 @@ describe("Timeline", () => {
       expect(timeline.children.length).toEqual(2);
     });
 
+    it("respects dynamically removed end child node descriptions", async () => {
+      TestPlugin.setManualFinishTrialMode();
+
+      const timelineDescription: TimelineArray = [
+        { type: TestPlugin },
+        { type: TestPlugin },
+        { timeline: [{ type: TestPlugin }] },
+      ];
+      const timeline = createTimeline(timelineDescription);
+
+      const runPromise = timeline.run();
+      expect(timeline.children.length).toEqual(1); // Only the first child is instantiated because they are incrementally instantiated now
+
+      timelineDescription.pop();
+      await TestPlugin.finishTrial();
+      await TestPlugin.finishTrial();
+      await runPromise;
+
+      expect(timeline.children.length).toEqual(2);
+      expect(timeline.children).toEqual([expect.any(Trial), expect.any(Trial)]);
+    });
+
+    it("respects dynamically removed first child node descriptions", async () => {
+      TestPlugin.setManualFinishTrialMode();
+
+      const timelineDescription: TimelineArray = [
+        { type: TestPlugin },
+        { timeline: [{ type: TestPlugin }] },
+        { type: TestPlugin },
+      ];
+      const timeline = createTimeline(timelineDescription);
+
+      const runPromise = timeline.run();
+      expect(timeline.children.length).toEqual(1);
+
+      timelineDescription.shift();
+      await TestPlugin.finishTrial();
+      await TestPlugin.finishTrial();
+      await runPromise;
+
+      expect(timeline.children.length).toEqual(2);
+      expect(timeline.children).toEqual([expect.any(Timeline), expect.any(Trial)]);
+    });
+
+    it("respects dynamically removed middle child node descriptions", async () => {
+      TestPlugin.setManualFinishTrialMode();
+
+      const timelineDescription: TimelineArray = [
+        { type: TestPlugin },
+        { timeline: [{ type: TestPlugin }] },
+        { type: TestPlugin },
+      ];
+      const timeline = createTimeline(timelineDescription);
+
+      const runPromise = timeline.run();
+      expect(timeline.children.length).toEqual(1);
+
+      timelineDescription.splice(1, 1);
+      await TestPlugin.finishTrial();
+      await TestPlugin.finishTrial();
+      await runPromise;
+
+      expect(timeline.children.length).toEqual(2);
+      expect(timeline.children).toEqual([expect.any(Trial), expect.any(Trial)]);
+    });
+
     describe("with `pause()` and `resume()` calls`", () => {
       beforeEach(() => {
         TestPlugin.setManualFinishTrialMode();

--- a/packages/jspsych/src/timeline/Timeline.spec.ts
+++ b/packages/jspsych/src/timeline/Timeline.spec.ts
@@ -75,6 +75,40 @@ describe("Timeline", () => {
       expect(timeline.children.length).toEqual(2);
     });
 
+    it("respects dynamically added child node descriptions at the start", async () => {
+      TestPlugin.setManualFinishTrialMode();
+
+      const timelineDescription: TimelineArray = [{ type: TestPlugin }];
+      const timeline = createTimeline(timelineDescription);
+
+      const runPromise = timeline.run();
+      expect(timeline.children.length).toEqual(1);
+
+      timelineDescription.splice(0, 0, { timeline: [{ type: TestPlugin }] });
+      await TestPlugin.finishTrial();
+      await TestPlugin.finishTrial();
+      await runPromise;
+
+      expect(timeline.children.length).toEqual(2);
+    });
+
+    it("dynamically added child node descriptions before a node after it has been run", async () => {
+      TestPlugin.setManualFinishTrialMode();
+
+      const timelineDescription: TimelineArray = [{ type: TestPlugin }];
+      const timeline = createTimeline(timelineDescription);
+
+      const runPromise = timeline.run();
+      expect(timeline.children.length).toEqual(1);
+
+      await TestPlugin.finishTrial();
+      timelineDescription.splice(0, 0, { timeline: [{ type: TestPlugin }] });
+      await TestPlugin.finishTrial();
+      await runPromise;
+
+      expect(timeline.children.length).toEqual(1);
+    });
+
     it("respects dynamically removed end child node descriptions", async () => {
       TestPlugin.setManualFinishTrialMode();
 

--- a/packages/jspsych/src/timeline/Timeline.spec.ts
+++ b/packages/jspsych/src/timeline/Timeline.spec.ts
@@ -119,6 +119,30 @@ describe("Timeline", () => {
       expect(timeline.children).toEqual([expect.any(Trial), expect.any(Trial)]);
     });
 
+    it("dynamically remove first node after running it", async () => {
+      TestPlugin.setManualFinishTrialMode();
+
+      const timelineDescription: TimelineArray = [
+        { type: TestPlugin, data: { I: 0 } },
+        { timeline: [{ type: TestPlugin, data: { I: 1 } }] },
+        { type: TestPlugin, data: { I: 2 } },
+        { type: TestPlugin, data: { I: 3 } },
+      ];
+      const timeline = createTimeline(timelineDescription);
+
+      const runPromise = timeline.run();
+      await TestPlugin.finishTrial();
+      timelineDescription.shift();
+      await TestPlugin.finishTrial();
+      await TestPlugin.finishTrial();
+      await runPromise;
+
+      expect(timeline.children.length).toEqual(3);
+      expect(timeline.children[0].getDataParameter().I).toEqual(0);
+      expect(timeline.children[1].description.timeline[0]).toHaveProperty("data.I", 1);
+      expect(timeline.children[2].getDataParameter().I).toEqual(3);
+    });
+
     describe("with `pause()` and `resume()` calls`", () => {
       beforeEach(() => {
         TestPlugin.setManualFinishTrialMode();

--- a/packages/jspsych/src/timeline/Timeline.spec.ts
+++ b/packages/jspsych/src/timeline/Timeline.spec.ts
@@ -139,7 +139,8 @@ describe("Timeline", () => {
 
       expect(timeline.children.length).toEqual(3);
       expect(timeline.children[0].getDataParameter().I).toEqual(0);
-      expect(timeline.children[1].description.timeline[0]).toHaveProperty("data.I", 1);
+      const secondChildDescription = timeline.children[1].description as TimelineDescription;
+      expect(secondChildDescription["timeline"][0]).toHaveProperty("data.I", 1);
       expect(timeline.children[2].getDataParameter().I).toEqual(3);
     });
 

--- a/packages/jspsych/src/timeline/Timeline.spec.ts
+++ b/packages/jspsych/src/timeline/Timeline.spec.ts
@@ -80,8 +80,8 @@ describe("Timeline", () => {
 
       const timelineDescription: TimelineArray = [
         { type: TestPlugin },
-        { type: TestPlugin },
         { timeline: [{ type: TestPlugin }] },
+        { type: TestPlugin },
       ];
       const timeline = createTimeline(timelineDescription);
 
@@ -94,7 +94,7 @@ describe("Timeline", () => {
       await runPromise;
 
       expect(timeline.children.length).toEqual(2);
-      expect(timeline.children).toEqual([expect.any(Trial), expect.any(Trial)]);
+      expect(timeline.children).toEqual([expect.any(Trial), expect.any(Timeline)]);
     });
 
     it("respects dynamically removed first child node descriptions", async () => {

--- a/packages/jspsych/src/timeline/Timeline.spec.ts
+++ b/packages/jspsych/src/timeline/Timeline.spec.ts
@@ -97,28 +97,6 @@ describe("Timeline", () => {
       expect(timeline.children).toEqual([expect.any(Trial), expect.any(Timeline)]);
     });
 
-    it("respects dynamically removed first child node descriptions", async () => {
-      TestPlugin.setManualFinishTrialMode();
-
-      const timelineDescription: TimelineArray = [
-        { type: TestPlugin },
-        { timeline: [{ type: TestPlugin }] },
-        { type: TestPlugin },
-      ];
-      const timeline = createTimeline(timelineDescription);
-
-      const runPromise = timeline.run();
-      expect(timeline.children.length).toEqual(1);
-
-      timelineDescription.shift();
-      await TestPlugin.finishTrial();
-      await TestPlugin.finishTrial();
-      await runPromise;
-
-      expect(timeline.children.length).toEqual(2);
-      expect(timeline.children).toEqual([expect.any(Timeline), expect.any(Trial)]);
-    });
-
     it("respects dynamically removed middle child node descriptions", async () => {
       TestPlugin.setManualFinishTrialMode();
 

--- a/packages/jspsych/src/timeline/Timeline.spec.ts
+++ b/packages/jspsych/src/timeline/Timeline.spec.ts
@@ -75,23 +75,6 @@ describe("Timeline", () => {
       expect(timeline.children.length).toEqual(2);
     });
 
-    it("respects dynamically added child node descriptions at the start", async () => {
-      TestPlugin.setManualFinishTrialMode();
-
-      const timelineDescription: TimelineArray = [{ type: TestPlugin }];
-      const timeline = createTimeline(timelineDescription);
-
-      const runPromise = timeline.run();
-      expect(timeline.children.length).toEqual(1);
-
-      timelineDescription.splice(0, 0, { timeline: [{ type: TestPlugin }] });
-      await TestPlugin.finishTrial();
-      await TestPlugin.finishTrial();
-      await runPromise;
-
-      expect(timeline.children.length).toEqual(2);
-    });
-
     it("dynamically added child node descriptions before a node after it has been run", async () => {
       TestPlugin.setManualFinishTrialMode();
 

--- a/packages/jspsych/src/timeline/Timeline.ts
+++ b/packages/jspsych/src/timeline/Timeline.ts
@@ -75,7 +75,9 @@ export class Timeline extends TimelineNode {
           for (const timelineVariableIndex of timelineVariableOrder) {
             this.setCurrentTimelineVariablesByIndex(timelineVariableIndex);
 
-            for (const childNode of this.instantiateChildNodes()) {
+            for (const childNodeDescription of this.description.timeline) {
+              const childNode = this.instantiateChildNode(childNodeDescription);
+
               const previousChild = this.currentChild;
               this.currentChild = childNode;
               childNode.index = previousChild
@@ -151,14 +153,15 @@ export class Timeline extends TimelineNode {
     }
   }
 
-  private instantiateChildNodes() {
-    const newChildNodes = this.description.timeline.map((childDescription) => {
-      return isTimelineDescription(childDescription)
-        ? new Timeline(this.dependencies, childDescription, this)
-        : new Trial(this.dependencies, childDescription, this);
-    });
-    this.children.push(...newChildNodes);
-    return newChildNodes;
+  private instantiateChildNode(
+    childDescription: TimelineDescription | TimelineArray | TrialDescription
+  ) {
+    const newChildNode = isTimelineDescription(childDescription)
+      ? new Timeline(this.dependencies, childDescription, this)
+      : new Trial(this.dependencies, childDescription, this);
+
+    this.children.push(newChildNode);
+    return newChildNode;
   }
 
   private currentTimelineVariables: Record<string, any>;


### PR DESCRIPTION
Prior to this, trials (or nested timelines) that were added to a timeline description while the experiment was running would be ignored. This PR makes `Timeline` objects instantiate their child nodes incrementally before running them, thus accounting for dynamically added/removed trials and timelines.

Closes #3379.

---

While I'm confident in the implementation, I'm submitting this as a draft for now because it lacks docs updates and a changeset (for which I don't have time ATM). @jspsych/core Feel free to complete this and release it!

I'm also not sure to which extent modifications to a JS array are reflected while iterating over it in a `for ... of` loop – it would be interesting to toy around with this a bit. Pushing elements to the end obviously works (and is the primary use case anyway), but what about removing elements prior to the current one? Index-based iteration would skip an element then – but maybe  `for ... of` doesn't?