### PR TITLE
fix COMPLEX type metadata syntax

### DIFF
--- a/.changeset/ten-walls-double.md
+++ b/.changeset/ten-walls-double.md
@@ -1,0 +1,9 @@
+---
+"@jspsych/plugin-animation": patch
+"@jspsych/plugin-free-sort": patch
+"@jspsych/plugin-instructions": patch
+"@jspsych/plugin-maxdiff": patch
+"@jspsych/plugin-sketchpad": patch
+---
+
+fix data values with `COMPLEX` type to use proper metadata syntax

--- a/packages/plugin-animation/src/index.ts
+++ b/packages/plugin-animation/src/index.ts
@@ -65,7 +65,7 @@ const info = <const>{
     animation_sequence: {
       type: ParameterType.COMPLEX,
       array: true,
-      parameters: {
+      nested: {
         stimulus: {
           type: ParameterType.STRING,
         },
@@ -83,7 +83,7 @@ const info = <const>{
     response: {
       type: ParameterType.COMPLEX,
       array: true,
-      parameters: {
+      nested: {
         stimulus: {
           type: ParameterType.STRING,
         },

--- a/packages/plugin-free-sort/src/index.ts
+++ b/packages/plugin-free-sort/src/index.ts
@@ -134,7 +134,7 @@ const info = <const>{
     moves: {
       type: ParameterType.COMPLEX,
       array: true,
-      parameters: {
+      nested: {
         src: {
           type: ParameterType.STRING,
         },
@@ -150,7 +150,7 @@ const info = <const>{
     final_locations: {
       type: ParameterType.COMPLEX,
       array: true,
-      parameters: {
+      nested: {
         src: {
           type: ParameterType.STRING,
         },

--- a/packages/plugin-instructions/src/index.ts
+++ b/packages/plugin-instructions/src/index.ts
@@ -78,7 +78,7 @@ const info = <const>{
     view_history: {
       type: ParameterType.COMPLEX,
       array: true,
-      parameters: {
+      nested: {
         page_index: {
           type: ParameterType.INT,
         },

--- a/packages/plugin-maxdiff/src/index.ts
+++ b/packages/plugin-maxdiff/src/index.ts
@@ -52,7 +52,7 @@ const info = <const>{
      * columns. This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions.  */
     labels: {
       type: ParameterType.COMPLEX,
-      parameters: {
+      nested: {
         left: {
           type: ParameterType.STRING,
         },
@@ -65,7 +65,7 @@ const info = <const>{
      * This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions. */
     response: {
       type: ParameterType.COMPLEX,
-      parameters: {
+      nested: {
         left: {
           type: ParameterType.STRING,
         },

--- a/packages/plugin-sketchpad/src/index.ts
+++ b/packages/plugin-sketchpad/src/index.ts
@@ -232,7 +232,7 @@ const info = <const>{
     strokes: {
       type: ParameterType.COMPLEX,
       array: true,
-      parameters: {
+      nested: {
         action: {
           type: ParameterType.STRING,
         },


### PR DESCRIPTION
this PR fixes all instances of data produced by plugins with `ParameterType.COMPLEX` type with an improper `parameter` field, as the supported way to nest parameters is with the `nested` field.