### PR TITLE
force dom to clear after each individual test case

### DIFF
--- a/.changeset/swift-rivers-deliver.md
+++ b/.changeset/swift-rivers-deliver.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/config": minor
+---
+
+update to force the dom to clear after each individual test

--- a/packages/config/jest.cjs
+++ b/packages/config/jest.cjs
@@ -19,5 +19,6 @@ module.exports.makePackageConfig = (dirname) => {
       name: packageBaseName,
       color: packageBaseName === "jspsych" ? "white" : "cyanBright",
     },
+    setupFilesAfterEnv: ["../config/jest.setup.js"],
   };
 };

--- a/packages/config/jest.setup.js
+++ b/packages/config/jest.setup.js
@@ -1,0 +1,3 @@
+global.afterEach(() => {
+    document.body.innerHTML = '';
+});


### PR DESCRIPTION
this PR clears the dom after every individual test. the expected pattern of using `startTimeline` in the `test-utils` package is to deconstruct the tuple given and take out `displayElement` in order to directly query the experiment's display element. however, some plugins still query `document` directly, which isn't optimal as the dom is not cleared, meaning there are multiple jsPsych display elements on the dom at a given time. this results in some interesting edge cases where the wrong button is queried, or one test failing means every next test that interacts with the `document` fails.

this is a small, simple update in order to allow tests to both query `document` and `displayElement` without having to deal with this behavior by making sure the DOM is wiped before each individual test.