### PR TITLE
fix missing data field in `audio-button-response` plugin

### DIFF
--- a/.changeset/red-news-pull.md
+++ b/.changeset/red-news-pull.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/plugin-audio-button-response": patch
+---
+
+annotate missing stimulus data field

--- a/docs/plugins/audio-button-response.md
+++ b/docs/plugins/audio-button-response.md
@@ -37,6 +37,7 @@ In addition to the [default data collected by all plugins](../overview/plugins.m
 | -------------- | ------- | ---------------------------------------- |
 | rt             | numeric | The response time in milliseconds for the participant to make a response. The time is measured from when the stimulus first began playing until the participant's response. |
 | response       | numeric | Indicates which button the participant pressed. The first button in the `choices` array is 0, the second is 1, and so on. |
+| stimulus       | string  | Path to the audio file that played during the trial. |
 
 ## Simulation Mode
 

--- a/packages/plugin-audio-button-response/src/index.ts
+++ b/packages/plugin-audio-button-response/src/index.ts
@@ -100,6 +100,10 @@ const info = <const>{
     },
   },
   data: {
+    /** The path of the audio file that was played. */
+    stimulus: {
+      type: ParameterType.STRING,
+    },
     /** The response time in milliseconds for the participant to make a response. The time is measured from
      * when the stimulus first began playing until the participant's response.*/
     rt: {


### PR DESCRIPTION
hi all, just a very small addition to the `audio-button-response` plugin, the stimulus data field was missing (but the trial still generated the stimulus data) as per #3316. this has been added and the docs have been updated to match. doesn't look like this is an issue in other plugins, just this one.