### PR TITLE
fix `response` data type to be just `ParameterType.OBJECT`

### DIFF
--- a/.changeset/strange-countries-laugh.md
+++ b/.changeset/strange-countries-laugh.md
@@ -1,0 +1,10 @@
+---
+"@jspsych/plugin-survey": patch
+"@jspsych/plugin-survey-html-form": patch
+"@jspsych/plugin-survey-likert": patch
+"@jspsych/plugin-survey-multi-choice": patch
+"@jspsych/plugin-survey-multi-select": patch
+"@jspsych/plugin-survey-text": patch
+---
+
+fix `response` data type to be just `ParameterType.OBJECT`

--- a/packages/plugin-survey-html-form/src/index.ts
+++ b/packages/plugin-survey-html-form/src/index.ts
@@ -40,20 +40,7 @@ const info = <const>{
   data: {
     /**  An object containing the response for each input. The object will have a separate key (variable) for the response to each input, with each variable being named after its corresponding input element. Each response is a string containing whatever the participant answered for this particular input. This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions. */
     response: {
-      type: ParameterType.COMPLEX,
-      nested: {
-        identifier: {
-          type: ParameterType.STRING,
-        },
-        response: {
-          type:
-            ParameterType.STRING |
-            ParameterType.INT |
-            ParameterType.FLOAT |
-            ParameterType.BOOL |
-            ParameterType.OBJECT,
-        },
-      },
+      type: ParameterType.OBJECT,
     },
     /** The response time in milliseconds for the participant to make a response. */
     rt: {

--- a/packages/plugin-survey-likert/src/index.ts
+++ b/packages/plugin-survey-likert/src/index.ts
@@ -63,20 +63,7 @@ const info = <const>{
   data: {
     /** An object containing the response for each question. The object will have a separate key (variable) for each question, with the first question in the trial being recorded in `Q0`, the second in `Q1`, and so on. The responses are recorded as integers, representing the position selected on the likert scale for that question. If the `name` parameter is defined for the question, then the response object will use the value of `name` as the key for each question. This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions. */
     response: {
-      type: ParameterType.COMPLEX,
-      nested: {
-        identifier: {
-          type: ParameterType.STRING,
-        },
-        response: {
-          type:
-            ParameterType.STRING |
-            ParameterType.INT |
-            ParameterType.FLOAT |
-            ParameterType.BOOL |
-            ParameterType.OBJECT,
-        },
-      },
+      type: ParameterType.OBJECT,
     },
     /** The response time in milliseconds for the participant to make a response. The time is measured from when the questions first appear on the screen until the participant's response(s) are submitted. */
     rt: {

--- a/packages/plugin-survey-multi-choice/src/index.ts
+++ b/packages/plugin-survey-multi-choice/src/index.ts
@@ -80,20 +80,7 @@ const info = <const>{
   data: {
     /** An object containing the response for each question. The object will have a separate key (variable) for each question, with the first question in the trial being recorded in `Q0`, the second in `Q1`, and so on. The responses are recorded as integers, representing the position selected on the likert scale for that question. If the `name` parameter is defined for the question, then the response object will use the value of `name` as the key for each question. This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions. */
     response: {
-      type: ParameterType.COMPLEX,
-      nested: {
-        identifier: {
-          type: ParameterType.STRING,
-        },
-        response: {
-          type:
-            ParameterType.STRING |
-            ParameterType.INT |
-            ParameterType.FLOAT |
-            ParameterType.BOOL |
-            ParameterType.OBJECT,
-        },
-      },
+      type: ParameterType.OBJECT,
     },
     /** The response time in milliseconds for the participant to make a response. The time is measured from when the questions first appear on the screen until the participant's response(s) are submitted. */
     rt: {

--- a/packages/plugin-survey-multi-select/src/index.ts
+++ b/packages/plugin-survey-multi-select/src/index.ts
@@ -85,20 +85,7 @@ const info = <const>{
   data: {
     /** An object containing the response for each question. The object will have a separate key (variable) for each question, with the first question in the trial being recorded in `Q0`, the second in `Q1`, and so on. The responses are recorded as integers, representing the position selected on the likert scale for that question. If the `name` parameter is defined for the question, then the response object will use the value of `name` as the key for each question. This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions. */
     response: {
-      type: ParameterType.COMPLEX,
-      nested: {
-        identifier: {
-          type: ParameterType.STRING,
-        },
-        response: {
-          type:
-            ParameterType.STRING |
-            ParameterType.INT |
-            ParameterType.FLOAT |
-            ParameterType.BOOL |
-            ParameterType.OBJECT,
-        },
-      },
+      type: ParameterType.OBJECT,
     },
     /** The response time in milliseconds for the participant to make a response. The time is measured from when the questions first appear on the screen until the participant's response(s) are submitted. */
     rt: {

--- a/packages/plugin-survey-text/src/index.ts
+++ b/packages/plugin-survey-text/src/index.ts
@@ -83,20 +83,7 @@ const info = <const>{
   data: {
     /** An object containing the response for each question. The object will have a separate key (variable) for each question, with the first question in the trial being recorded in `Q0`, the second in `Q1`, and so on. The responses are recorded as integers, representing the position selected on the likert scale for that question. If the `name` parameter is defined for the question, then the response object will use the value of `name` as the key for each question. This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions. */
     response: {
-      type: ParameterType.COMPLEX,
-      nested: {
-        identifier: {
-          type: ParameterType.STRING,
-        },
-        response: {
-          type:
-            ParameterType.STRING |
-            ParameterType.INT |
-            ParameterType.FLOAT |
-            ParameterType.BOOL |
-            ParameterType.OBJECT,
-        },
-      },
+      type: ParameterType.OBJECT,
     },
     /** The response time in milliseconds for the participant to make a response. The time is measured from when the questions first appear on the screen until the participant's response(s) are submitted. */
     rt: {

--- a/packages/plugin-survey/src/index.ts
+++ b/packages/plugin-survey/src/index.ts
@@ -46,20 +46,7 @@ const info = <const>{
   data: {
     /** An object containing the response to each question. The object will have a separate key (identifier) for each question. If the `name` parameter is defined for the question (recommended), then the response object will use the value of `name` as the key for each question. If any questions do not have a name parameter, their keys will named automatically, with the first unnamed question recorded as `question1`, the second as `question2`, and so on. The response type will depend on the question type. This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions. */
     response: {
-      type: ParameterType.COMPLEX,
-      nested: {
-        identifier: {
-          type: ParameterType.STRING,
-        },
-        response: {
-          type:
-            ParameterType.STRING |
-            ParameterType.INT |
-            ParameterType.FLOAT |
-            ParameterType.BOOL |
-            ParameterType.OBJECT,
-        },
-      },
+      type: ParameterType.OBJECT,
     },
     /** The response time in milliseconds for the participant to make a response. The time is measured from when the questions first appear on the screen until the participant's response(s) are submitted. */
     rt: {


### PR DESCRIPTION
this PR does as described, fixing up an erroneous data type (multiple `ParameterType`s are unsupported in jsPsych's current configuration, so we'll just default to a simple object type). this is to ensure that any tooling/new plugins created and referenced with these plugins in mind use the correct specifications.

