### PR TITLE
Improve error message for missing type parameter

### DIFF
--- a/packages/jspsych/src/timeline/Trial.ts
+++ b/packages/jspsych/src/timeline/Trial.ts
@@ -35,6 +35,11 @@ export class Trial extends TimelineNode {
 
     this.trialObject = deepCopy(description);
     this.pluginClass = this.getParameterValue("type", { evaluateFunctions: false });
+    if (this.pluginClass === undefined || this.pluginClass["info"] === undefined) {
+      throw new Error(
+        "Trial plugin not recognized. Please provide a valid plugin using the 'type' parameter."
+      );
+    }
     this.pluginInfo = this.pluginClass["info"];
 
     if (!("version" in this.pluginInfo) && !("data" in this.pluginInfo)) {


### PR DESCRIPTION
A missing `type` parameter returns unfriendly errors such as `TypeError: Cannot read properties of undefined (reading 'info')`.  
 Added a clearer error message with a check that the `type` parameter is provided and is associated with an `info` object.

# Testing
`npm test`
