### PR TITLE
BUG: Compiler error cannot find script

### DIFF
--- a/.changeset/thick-waves-bathe.md
+++ b/.changeset/thick-waves-bathe.md
@@ -1,0 +1,5 @@
+---
+"jspsych": patch
+---
+
+Modify import of seedrandom to fix build issue with some configurations of webpack

--- a/packages/jspsych/src/modules/randomization.ts
+++ b/packages/jspsych/src/modules/randomization.ts
@@ -1,5 +1,5 @@
 import rw from "random-words";
-import seedrandom from "seedrandom/lib/alea";
+import seedrandom from "seedrandom/lib/alea.js";
 
 /**
  * Uses the `seedrandom` package to replace Math.random() with a seedable PRNG.


### PR DESCRIPTION
```
$ npx webpack --mode=development
assets by path assets/ 202 KiB
  asset assets/favicon.ico 200 KiB [compared for emit]
  asset assets/experimentDesignerParameters.json 1.46 KiB [compared for emit] [from: assets/experimentDesignerParameters.json] [copied]
  asset assets/experimentParameters.json 49 bytes [compared for emit] [from: assets/experimentParameters.json] [copied]
asset bundle.js 3.83 MiB [compared for emit] (name: main) 1 related asset
asset index.html 324 bytes [emitted]
asset css/main.css 316 bytes [compared for emit] [from: css/main.css] [copied]
runtime modules 3.65 KiB 10 modules
cacheable modules 1.58 MiB
  javascript modules 1.14 MiB
    modules by path ./node_modules/ 1.13 MiB 31 modules
    modules by path ./css/*.css 2.44 KiB 2 modules
    ./src/index.js 11.9 KiB [built] [code generated]
    crypto (ignored) 15 bytes [optional] [built] [code generated]
  asset modules 452 KiB
    data:font/woff2;charset=utf-8;base64,d09GMgABAAAAAEmM.. 24.7 KiB [built] [code generated]
    data:font/woff2;charset=utf-8;base64,d09GMgABAAAAAC0c.. 15.1 KiB [built] [code generated]
    data:font/woff2;charset=utf-8;base64,d09GMgABAAAAAA8c.. 5.1 KiB [built] [code generated]
    data:font/woff2;charset=utf-8;base64,d09GMgABAAAAACSg.. 12.3 KiB [built] [code generated]
    data:font/woff2;charset=utf-8;base64,d09GMgABAAAAAB4k.. 10.1 KiB [built] [code generated]
    + 27 modules

LOG from favicons-webpack-plugin
<i> generate only a single favicon for fast compilation time in development mode. This behaviour can be changed by setting the favicon mode option.

ERROR in ./node_modules/jspsych/dist/index.js 3:0-45
Module not found: Error: Can't resolve 'seedrandom/lib/alea' in '/home/test/node_modules/jspsych/dist'
Did you mean 'alea.js'?
BREAKING CHANGE: The request 'seedrandom/lib/alea' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
resolve 'seedrandom/lib/alea' in /home/test/node_modules/jspsych/dist'
  Parsed request is a module
  using description file: /home/test/node_modules/jspsych/package.json (relative path: ./dist)
    Field 'browser' doesn't contain a valid alias configuration
    resolve as module
      /home/test/node_modules/jspsych/dist/node_modules doesn't exist or is not a directory
      /home/test/node_modules/jspsych/node_modules doesn't exist or is not a directory
      /home/test/node_modules/node_modules doesn't exist or is not a directory
      looking for modules in/home/test/node_modules
        existing directory /home/test/node_modules/seedrandom
          using description file: /home/test/node_modules/seedrandom/package.json (relative path: .)
            using description file: /home/test/node_modules/seedrandom/package.json (relative path: ./lib/alea)
              /home/test/node_modules/seedrandom/lib/alea doesn't exist
      /home/test/forest/node_modules doesn't exist or is not a directory
      /home/test/node_modules doesn't exist or is not a directory
      /home/node_modules doesn't exist or is not a directory
      /node_modules doesn't exist or is not a directory
 @ ./src/index.js 19:0-38 56:16-27

webpack 5.97.1 compiled with 1 error in 513 ms
```

I'm getting a compiler error using webpack that the reference needs to have the extension. This change fixes that error so that my project compiles. I don't know much about the test suite and if this setup is covered so not sure why it doesn't fail on other setups. Anyway, not sure if this is a problem for other people but just making a PR in case it helps.