### PR TITLE
Use glob v7 for jspsych/config

### DIFF
--- a/.changeset/small-swans-applaud.md
+++ b/.changeset/small-swans-applaud.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/config": patch
+---
+
+Fixes gulp build process that was attempting to use glob v10 by adding glob v7 as explicit dependency. glob v9+ changed the API and would require some rewrites and testing before implementing

--- a/package-lock.json
+++ b/package-lock.json
@@ -16078,6 +16078,7 @@
         "app-root-path": "^3.1.0",
         "canvas": "^2.11.2",
         "esbuild": "0.23.1",
+        "glob": "7.2.3",
         "gulp": "5.0.0",
         "gulp-cli": "3.0.0",
         "gulp-file": "0.4.0",
@@ -16099,6 +16100,46 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/config/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/config/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/config/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "packages/config/node_modules/yaml": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -49,6 +49,7 @@
     "app-root-path": "^3.1.0",
     "canvas": "^2.11.2",
     "esbuild": "0.23.1",
+    "glob": "7.2.3",
     "gulp": "5.0.0",
     "gulp-cli": "3.0.0",
     "gulp-file": "0.4.0",


### PR DESCRIPTION
This adds glob as an explicit dependency in jspsych/config to ensure that version 7 is used in our scripts. glob v9+ updated their API and would require us to make some changes.