### PR TITLE
Adjustments for embedding in a host app

### DIFF
--- a/packages/jspsych/src/index.ts
+++ b/packages/jspsych/src/index.ts
@@ -1,6 +1,6 @@
 // __rollup-babel-import-regenerator-runtime__
 
-import { JsPsych } from "./JsPsych";
+import { JsPsych, JsPsychConstructorOptions } from "./JsPsych";
 import { MigrationError } from "./migration";
 
 // temporary patch for Safari
@@ -22,7 +22,7 @@ if (
  * @param options The options to pass to the JsPsych constructor
  * @returns A new JsPsych instance
  */
-export function initJsPsych(options?) {
+export function initJsPsych(options?: JsPsychConstructorOptions) {
   const jsPsych = new JsPsych(options);
 
   // Handle invocations of non-existent v6 methods with migration errors
@@ -66,3 +66,4 @@ export type { JsPsychPlugin, PluginInfo, TrialType } from "./modules/plugins";
 export { ParameterType } from "./modules/plugins";
 export type { JsPsychExtension, JsPsychExtensionInfo } from "./modules/extensions";
 export { DataCollection } from "./modules/data/DataCollection";
+export type { TimelineDescription, TimelineArray } from "./timeline";

--- a/packages/jspsych/src/modules/plugin-api/KeyboardListenerAPI.ts
+++ b/packages/jspsych/src/modules/plugin-api/KeyboardListenerAPI.ts
@@ -1,4 +1,5 @@
 import autoBind from "auto-bind";
+import { GlobalEventSource } from "src/JsPsych";
 
 export type KeyboardListener = (e: KeyboardEvent) => void;
 
@@ -17,7 +18,7 @@ export interface GetKeyboardResponseOptions {
 
 export class KeyboardListenerAPI {
   constructor(
-    private getRootElement: () => Element | undefined,
+    private getEventSource: () => GlobalEventSource | EventTarget | undefined,
     private areResponsesCaseSensitive: boolean = false,
     private minimumValidRt = 0
   ) {
@@ -36,11 +37,16 @@ export class KeyboardListenerAPI {
    */
   private registerRootListeners() {
     if (!this.areRootListenersRegistered) {
-      const rootElement = this.getRootElement();
-      if (rootElement) {
-        rootElement.addEventListener("keydown", this.rootKeydownListener);
-        rootElement.addEventListener("keyup", this.rootKeyupListener);
+      const source = this.getEventSource();
+      if (source) {
+        if (source instanceof Element && isNaN(parseInt(source.getAttribute("tabIndex")))) {
+          console.warn("non-numeric tabIndex on interactive element", source);
+        }
+        source.addEventListener("keydown", this.rootKeydownListener);
+        source.addEventListener("keyup", this.rootKeyupListener);
         this.areRootListenersRegistered = true;
+      } else {
+        console.warn("No source available for KeyboardListenerAPI", this.getEventSource);
       }
     }
   }

--- a/packages/jspsych/src/modules/plugin-api/index.ts
+++ b/packages/jspsych/src/modules/plugin-api/index.ts
@@ -9,7 +9,7 @@ import { TimeoutAPI } from "./TimeoutAPI";
 export function createJointPluginAPIObject(jsPsych: JsPsych) {
   const settings = jsPsych.getInitSettings();
   const keyboardListenerAPI = new KeyboardListenerAPI(
-    jsPsych.getDisplayContainerElement,
+    jsPsych.getMainEventSource,
     settings.case_sensitive_responses,
     settings.minimum_valid_rt
   );


### PR DESCRIPTION
In my project I want to launch JsPsych experiments from within a host "game".
For this, the host needs to be in control of what elements are used and which source to provide (keyboard) events.

Some additional typings are provided for the JsPsych constructor which was previously untyped.