### PR TITLE
parameter type mismatch checking + improvements to `ParameterType.SELECT`

### DIFF
--- a/.changeset/eleven-drinks-fail.md
+++ b/.changeset/eleven-drinks-fail.md
@@ -1,0 +1,5 @@
+---
+"jspsych": patch
+---
+
+parameter types will properly be checked in case of type mismatch, along with `ParameterType.SELECT` params properly using the `option` field to check if it is a valid parameter

--- a/packages/jspsych/src/modules/plugins.ts
+++ b/packages/jspsych/src/modules/plugins.ts
@@ -51,6 +51,7 @@ export type ParameterInfo = (
   array?: boolean;
   pretty_name?: string;
   default?: any;
+  options?: any;
 };
 
 export type ParameterInfos = Record<string, ParameterInfo>;

--- a/packages/jspsych/src/timeline/Trial.ts
+++ b/packages/jspsych/src/timeline/Trial.ts
@@ -360,6 +360,7 @@ export class Trial extends TimelineNode {
       for (const [parameterName, parameterConfig] of Object.entries(parameterInfos)) {
         const parameterPath = [...parentParameterPath, parameterName];
 
+        // evaluate parameter and validate required parameter
         let parameterValue = this.getParameterValue(parameterPath, {
           evaluateFunctions: parameterConfig.type !== ParameterType.FUNCTION,
           replaceResult: (originalResult) => {
@@ -379,6 +380,83 @@ export class Trial extends TimelineNode {
           },
         });
 
+        // major parameter type validation
+        if (!parameterConfig.array && parameterValue !== null) {
+          switch (parameterConfig.type) {
+            case ParameterType.BOOL:
+              if (typeof parameterValue !== "boolean") {
+                const parameterPathString = parameterPathArrayToString(parameterPath);
+                throw new Error(
+                  `A non-boolean value (\`${parameterValue}\`) was provided for the boolean parameter "${parameterPathString}" in the "${this.pluginInfo.name}" plugin.`
+                );
+              }
+              break;
+            // @ts-ignore falls through
+            case ParameterType.KEYS: // "ALL_KEYS", "NO_KEYS", and single key strings are checked here
+              if (Array.isArray(parameterValue)) 
+                break;
+            case ParameterType.STRING:
+            case ParameterType.HTML_STRING:
+            case ParameterType.KEY:
+            case ParameterType.AUDIO:
+            case ParameterType.VIDEO:
+            case ParameterType.IMAGE:
+              if (typeof parameterValue !== "string") {
+                const parameterPathString = parameterPathArrayToString(parameterPath);
+                throw new Error(
+                  `A non-string value (\`${parameterValue}\`) was provided for the parameter "${parameterPathString}" in the "${this.pluginInfo.name}" plugin.`
+                );
+              }
+              break;
+            case ParameterType.FLOAT:
+            case ParameterType.INT:
+              if (typeof parameterValue !== "number") {
+                const parameterPathString = parameterPathArrayToString(parameterPath);
+                throw new Error(
+                  `A non-numeric value (\`${parameterValue}\`) was provided for the numeric parameter "${parameterPathString}" in the "${this.pluginInfo.name}" plugin.`
+                );
+              }
+              break;
+            case ParameterType.FUNCTION:
+              if (typeof parameterValue !== "function") {
+                const parameterPathString = parameterPathArrayToString(parameterPath);
+                throw new Error(
+                  `A non-function value (\`${parameterValue}\`) was provided for the function parameter "${parameterPathString}" in the "${this.pluginInfo.name}" plugin.`
+                );
+              }
+              break;
+            case ParameterType.SELECT:
+              if (!parameterConfig.options) {
+                const parameterPathString = parameterPathArrayToString(parameterPath);
+                throw new Error(
+                  `The "options" array is required for the "select" parameter "${parameterPathString}" in the "${this.pluginInfo.name}" plugin.`
+                );
+              }
+          }
+
+          // truncate floats to integers if the parameter type is INT
+          if (parameterConfig.type === ParameterType.INT && parameterValue % 1 !== 0) {
+            const parameterPathString = parameterPathArrayToString(parameterPath);
+            console.warn(
+              `A float value (\`${parameterValue}\`) was provided for the integer parameter "${parameterPathString}" in the "${this.pluginInfo.name}" plugin. The value will be truncated to an integer.`
+            );
+
+            parameterValue = Math.trunc(parameterValue);
+          }
+        }
+
+        if (parameterConfig.type === ParameterType.SELECT) {
+          if (!parameterConfig.options.includes(parameterValue)) {
+            const parameterPathString = parameterPathArrayToString(parameterPath);
+            throw new Error(
+              `The value "${parameterValue}" is not a valid option for the parameter "${parameterPathString}" in the "${this.pluginInfo.name}" plugin. Valid options are: ${parameterConfig.options.join(
+                ", "
+              )}.`
+            );
+          }
+        }
+
+        // array validation
         if (parameterConfig.array && !Array.isArray(parameterValue)) {
           const parameterPathString = parameterPathArrayToString(parameterPath);
           throw new Error(


### PR DESCRIPTION
trials will now properly check if non-array parameters given are of the same type, throwing an error if not in order to give more helpful error message as opposed to some variation of some method being called on a mismatched type not existing. along with this, `ParameterType.SELECT` now properly checks if the value given is in the `options` field; plugin developers may now specify certain possible parameter values for a parameter removing the need for manual parameter input validation. 

this PR depends on #3556, as the `video-*-response` plugins have a parameter type mismatch with their default values, causing their respective tests to fail.