### PR TITLE
Add `survey.min.css` to the dist archive

### DIFF
--- a/.changeset/friendly-geckos-invite.md
+++ b/.changeset/friendly-geckos-invite.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/config": minor
+---
+
+Add the minified version of the survey plugin CSS file, `survey.min.css`, to the dist archive.

--- a/packages/config/gulp.js
+++ b/packages/config/gulp.js
@@ -84,6 +84,7 @@ export const createCoreDistArchive = () =>
 
     // survey.css
     src("packages/plugin-survey/css/survey.css").pipe(rename("/dist/survey.css")),
+    src("packages/plugin-survey/css/survey.min.css").pipe(rename("/dist/survey.min.css")),
 
     // Examples
     src("examples/**/*", { base: "." })


### PR DESCRIPTION
This PR adds the minified CSS file for the `survey` plugin to the core dist archive. The minified CSS file was added to the `survey` plugin here: #3554.

I wasn't sure whether this change to the `config` package needed to be in place before the `survey` plugin release or if it could be merged/released alongside it. I thought it would make sense to change this config package first, unless this package update will trigger another dist archive that will break because the `survey.min.css` file doesn't exist yet. If that's a problem, then would it work to release both package updates together?

It's also probably fine to leave this version of the CSS file out of the dist archive. I just put this PR up in case we want to include it.