### PR TITLE
fix: enable_button_after parameter in plugin-image-button-response (closes #3562)

### DIFF
--- a/.changeset/busy-tires-reply.md
+++ b/.changeset/busy-tires-reply.md
@@ -1,0 +1,5 @@
+---
+"@jspsych/plugin-image-button-response": minor
+---
+
+CSS selector that queries the button to disable it was trying to get a class. Now it looks for the correct id and disables the button.

--- a/packages/plugin-image-button-response/src/index.spec.ts
+++ b/packages/plugin-image-button-response/src/index.spec.ts
@@ -159,34 +159,6 @@ describe("image-button-response", () => {
       expect(btns[i].hasAttribute("disabled")).toBe(false);
     }
   });
-
-  test("buttons should be disabled and re-enabled with enable_button_after parameter", async () => {
-    const { displayElement } = await startTimeline([
-      {
-        type: imageButtonResponse,
-        stimulus: "../media/blue.png",
-        choices: ["Choice A", "Choice B"],
-        enable_button_after: 1000,
-        render_on_canvas: false,
-      },
-    ]);
-
-    const buttons = displayElement.querySelectorAll("button");
-
-    // All buttons should be disabled initially
-    buttons.forEach((button) => {
-      expect(button.hasAttribute("disabled")).toBe(true);
-      expect(button.getAttribute("disabled")).toBe("disabled");
-    });
-
-    // Advance time by 1000ms
-    jest.advanceTimersByTime(1000);
-
-    // All buttons should be enabled after the delay
-    buttons.forEach((button) => {
-      expect(button.hasAttribute("disabled")).toBe(false);
-    });
-  });
 });
 
 describe("image-button-response simulation", () => {

--- a/packages/plugin-image-button-response/src/index.spec.ts
+++ b/packages/plugin-image-button-response/src/index.spec.ts
@@ -159,6 +159,34 @@ describe("image-button-response", () => {
       expect(btns[i].hasAttribute("disabled")).toBe(false);
     }
   });
+
+  test("buttons should be disabled and re-enabled with enable_button_after parameter", async () => {
+    const { displayElement } = await startTimeline([
+      {
+        type: imageButtonResponse,
+        stimulus: "../media/blue.png",
+        choices: ["Choice A", "Choice B"],
+        enable_button_after: 1000,
+        render_on_canvas: false,
+      },
+    ]);
+
+    const buttons = displayElement.querySelectorAll("button");
+
+    // All buttons should be disabled initially
+    buttons.forEach((button) => {
+      expect(button.hasAttribute("disabled")).toBe(true);
+      expect(button.getAttribute("disabled")).toBe("disabled");
+    });
+
+    // Advance time by 1000ms
+    jest.advanceTimersByTime(1000);
+
+    // All buttons should be enabled after the delay
+    buttons.forEach((button) => {
+      expect(button.hasAttribute("disabled")).toBe(false);
+    });
+  });
 });
 
 describe("image-button-response simulation", () => {
@@ -199,10 +227,7 @@ describe("image-button-response simulation", () => {
       },
     ];
 
-    const { expectFinished, expectRunning, getData } = await simulateTimeline(
-      timeline,
-      "visual"
-    );
+    const { expectFinished, expectRunning, getData } = await simulateTimeline(timeline, "visual");
 
     await expectRunning();
 

--- a/packages/plugin-image-button-response/src/index.spec.ts
+++ b/packages/plugin-image-button-response/src/index.spec.ts
@@ -147,7 +147,7 @@ describe("image-button-response", () => {
       },
     ]);
 
-    const btns = displayElement.querySelectorAll(".jspsych-image-button-response-button button");
+    const btns = displayElement.querySelectorAll("#jspsych-image-button-response-btngroup button");
 
     for (let i = 0; i < btns.length; i++) {
       expect(btns[i].getAttribute("disabled")).toBe("disabled");

--- a/packages/plugin-image-button-response/src/index.spec.ts
+++ b/packages/plugin-image-button-response/src/index.spec.ts
@@ -199,7 +199,10 @@ describe("image-button-response simulation", () => {
       },
     ];
 
-    const { expectFinished, expectRunning, getData } = await simulateTimeline(timeline, "visual");
+    const { expectFinished, expectRunning, getData } = await simulateTimeline(
+      timeline,
+      "visual"
+    );
 
     await expectRunning();
 

--- a/packages/plugin-image-button-response/src/index.ts
+++ b/packages/plugin-image-button-response/src/index.ts
@@ -306,14 +306,14 @@ class ImageButtonResponsePlugin implements JsPsychPlugin<Info> {
     }
 
     function enable_buttons() {
-      var btns = document.querySelectorAll(".jspsych-image-button-response-button button");
+      var btns = document.querySelectorAll("#jspsych-image-button-response-btngroup button");
       for (var i = 0; i < btns.length; i++) {
         btns[i].removeAttribute("disabled");
       }
     }
 
     function disable_buttons() {
-      var btns = document.querySelectorAll(".jspsych-image-button-response-button button");
+      var btns = document.querySelectorAll("#jspsych-image-button-response-btngroup button");
       for (var i = 0; i < btns.length; i++) {
         btns[i].setAttribute("disabled", "disabled");
       }


### PR DESCRIPTION
CSS selector that queries the button to disable it was trying to get a class. Now it looks for the correct id and disables the button.

closes #3562 