### PR TITLE
Feat: add saving via API or locally for audio/video plugins

### DIFF
--- a/examples/jspsych-html-video-response.html
+++ b/examples/jspsych-html-video-response.html
@@ -27,6 +27,20 @@
     allow_playback: true
   }
 
+  // optional version that shows how to save the video both locally and via an API endpoint
+  // NOTE: you have to have your own API endpoint to test that feature here.
+  // const record_and_save_via_api = {
+  //   type: jsPsychHtmlVideoResponse,
+  //   stimulus: `<div style="width:100vw; height:100vh; position: relative;">
+  //     <div style="width:20px; height:20px; border-radius: 20px; background-color:red; position: absolute; top:10%; left:10%; transform: translate(-50%, -50%);"></div>
+  //     </div>`,
+  //   show_done_button: false,
+  //   recording_duration: 2000,
+  //   allow_playback: true,
+  //   save_locally: true,
+  //   // save_via_api: "https://yourserver.com/upload",
+  // }
+
   jsPsych.run([init_camera, record]);
 
 </script>

--- a/packages/plugin-html-audio-response/README.md
+++ b/packages/plugin-html-audio-response/README.md
@@ -8,6 +8,12 @@ The html-audio-response plugin displays HTML content and records audio from the 
 
 The audio data is recorded in base 64 format, which is a text representation of the audio that may be converted into others. Note that this plugin will _quickly_ generate large amounts of data, so if a large amount of audio needs to be recorded, consider storing the data on a server immediately and deleting it from the data object (This is shown in the documentation link below).
 
+In addition to the default base64 saving, this plugin now supports:
+- **Server upload** via the `save_via_api` parameter, which uploads the audio file to a specified API endpoint. A loading spinner and customizable `upload_wait_message` are shown during upload.
+- **Local file saving** via the `save_locally` parameter, which saves the audio file directly to the participant's default Downloads folder with a random UUID filename.
+
+These options can be used individually or together, and if neither is enabled, the original base64 behavior is preserved.
+
 ## Examples
 
 Several example experiments and plugin demonstrations are available in the `/examples` folder.

--- a/packages/plugin-html-video-response/README.md
+++ b/packages/plugin-html-video-response/README.md
@@ -6,11 +6,21 @@ jsPsych is a JavaScript framework for creating behavioral experiments that run i
 
 The html-video-response plugin displays HTML content and records video from the participant via a webcam. In order to get access to the webcam, use the [initialize-camera plugin](https://www.jspsych.org/7.3/plugins/initialize-camera/) before this plugin.
 
-The video data is recorded in base 64 format, which is a text representation of the video that may be converted into others. Note that this plugin will _quickly_ generate large amounts of data, so if a large amount of video needs to be recorded, consider storing the data on a server immediately and deleting it from the data object (This is shown in the documentation link below).
+The video data is by default recorded in base 64 format, which is a text representation of the video that may be converted into others. Note that this plugin will _quickly_ generate large amounts of data, so if a large amount of video needs to be recorded, consider storing the data on a server immediately and deleting it from the data object (This is shown in the documentation link below).
+
+Optionally, in addition to saving video data in the trial’s `response` field in base 64 format, this plugin can:
+- **Upload recordings directly to a server API endpoint** via the `save_via_api` parameter.
+- **Save recordings locally** to the participant’s default Downloads folder via the `save_locally` parameter.
+
+Both options automatically generate a unique filename for each recording (e.g., `a7fj2sd9.webm`). If `save_via_api` is used, the plugin expects the server to return a JSON object containing a `ref_id` field, which will be stored in the trial data for linking the trial to the saved file.  
+If neither option is enabled, the plugin behaves as before, storing the base 64 string in the trial data.
+
+Note that this plugin will _quickly_ generate large amounts of data, so if a large amount of video needs to be recorded, consider storing the data on a server immediately and deleting it from the data object (This is shown in the documentation link below).
 
 ## Examples
 
 Several example experiments and plugin demonstrations are available in the `/examples` folder.
+
 After you've downloaded the [latest release](https://github.com/jspsych/jsPsych/releases), double-click on an example HTML file to run it in your web browser, and open it with a programming-friendly text editor to see how it works.
 
 ## Documentation


### PR DESCRIPTION
This PR updates the `jspsych-html-video-response` and `jspsych-html-audio-response` plugins to support additional ways of saving audio/video data beyond storing base64-encoded text in the response field.

The new options are:

- **Save locally** – Downloads the recorded file directly to the participant’s default Downloads folder. (Web browsers do not allow arbitrary file system access from web pages, so saving elsewhere is not possible.) The saved filename is a randomly generated UUID, which is also stored in the response field of the jsPsych data. This allows the file to be linked to its trial data later, while keeping the file itself de-identified.

- **Save via API** – Uploads the recorded file to a specified API endpoint. The endpoint is expected to return the filename (or unique ID) it uses to store the file. This value will be stored in the response field of the jsPsych data. In most cases, we recommend generating a random UUID filename server-side and including it in the API response, so the trial data and file can be matched later without including identifying information in the file itself.

Because API uploads may take a few seconds, the plugin now displays a loading spinner during the upload. The accompanying text can be customised via the upload_wait_message parameter.

