### PR TITLE
pin rollup version to `^4.22.4`

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -64,7 +64,7 @@
     "jest-canvas-mock": "2.5.0",
     "jest-environment-jsdom": "29.7.0",
     "merge-stream": "2.0.0",
-    "rollup": ">=4.22.4",
+    "rollup": "^4.22.4",
     "rollup-plugin-dts": "6.1.1",
     "rollup-plugin-esbuild": "6.1.1",
     "rollup-plugin-modify": "^3.0.0",


### PR DESCRIPTION
good catch by @bjoluc, fixing up an issue from #3570 where the bounds was set as `>=` instead of `^`, meaning that a v5 update could and probably would break everything. since the changeset hasn't been merged yet, we can quickly patch this in.