### PR TITLE
Fix demos for video-* plugins

### DIFF
--- a/docs/demos/jspsych-video-button-response-demo1.html
+++ b/docs/demos/jspsych-video-button-response-demo1.html
@@ -16,7 +16,7 @@
 
     const preload = {
       type: jsPsychPreload,
-      video: 'video/fish.mp4'
+      video: ['video/fish.mp4']
     }
 
     const trial = {

--- a/docs/demos/jspsych-video-keyboard-response-demo1.html
+++ b/docs/demos/jspsych-video-keyboard-response-demo1.html
@@ -16,7 +16,7 @@
 
     const preload = {
       type: jsPsychPreload,
-      video: 'video/fish.mp4'
+      video: ['video/fish.mp4']
     }
 
     const trial = {

--- a/docs/demos/jspsych-video-slider-response-demo1.html
+++ b/docs/demos/jspsych-video-slider-response-demo1.html
@@ -16,7 +16,7 @@
 
     const preload = {
       type: jsPsychPreload,
-      video: 'video/fish.mp4'
+      video: ['video/fish.mp4']
     }
 
     const trial = {


### PR DESCRIPTION
This fixes the broken documentation demos for the following plugins:

- [Video keyboard response](https://www.jspsych.org/latest/plugins/video-keyboard-response/#examples)
- [Video slider response](https://www.jspsych.org/latest/plugins/video-slider-response/#example)
- [Video button response](https://www.jspsych.org/latest/plugins/video-button-response/#example)

The demos are broken because a string is passed to the preload plugin's `video` parameter, but the value must be an array. 