### PR TITLE
let test workflow fire on synchronize to trigger more appropriately

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
   pull_request:
-    types: [opened, reopened, ready_for_review, review_requested]
+    types: [opened, reopened, ready_for_review, review_requested, synchronize]
 
 jobs:
   test:


### PR DESCRIPTION
hopefully this makes it so that forks 30 days old (which would have deleted the old workflow) can still run tests when we commit new things to them... still don't know why that option was removed when it normally is but we'll see how this pans out 