### PR TITLE
ci: add per-PR jsDelivr preview build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,12 @@ name: build
 
 on:
   push:
+    # Preview branches contain only built dist artifacts (no source), so the
+    # build/lint/test job would always fail on them. They're created by the
+    # preview-publish workflow on every PR push, which would otherwise trigger
+    # this workflow many times per PR.
+    branches-ignore:
+      - 'preview/**'
   pull_request:
     types: [opened, reopened, ready_for_review, review_requested, synchronize]
 

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,73 @@
+name: preview-build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+# Runs in untrusted context for fork PRs: no secrets, no write permissions.
+# A separate workflow (preview-publish.yml) consumes the artifact in trusted context.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build preview dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Stage preview dist
+        run: |
+          set -euo pipefail
+          mkdir -p preview-dist/packages
+          for pkg in packages/*/; do
+            name=$(basename "$pkg")
+            if [ -d "${pkg}dist" ] || [ -d "${pkg}css" ]; then
+              mkdir -p "preview-dist/packages/$name"
+              [ -d "${pkg}dist" ] && cp -r "${pkg}dist" "preview-dist/packages/$name/"
+              [ -d "${pkg}css" ] && cp -r "${pkg}css" "preview-dist/packages/$name/"
+              [ -f "${pkg}package.json" ] && cp "${pkg}package.json" "preview-dist/packages/$name/"
+            fi
+          done
+
+      - name: Compute changed packages
+        id: changed
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          changed=$(git diff --name-only origin/main...HEAD -- 'packages/*' \
+            | awk -F/ 'NF>1 {print $2}' | sort -u | jq -R . | jq -sc .)
+          echo "packages=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Write metadata
+        run: |
+          cat > preview-dist/metadata.json <<EOF
+          {
+            "pr_number": ${{ github.event.pull_request.number }},
+            "head_sha": "${{ github.event.pull_request.head.sha }}",
+            "head_ref": "${{ github.event.pull_request.head.ref }}",
+            "changed_packages": ${{ steps.changed.outputs.packages }}
+          }
+          EOF
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: preview-dist
+          path: preview-dist/
+          retention-days: 3
+          if-no-files-found: error

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -49,7 +49,9 @@ jobs:
         id: changed
         run: |
           set -euo pipefail
-          git fetch origin main --depth=1
+          # Full fetch so the merge base for `origin/main...HEAD` is reachable;
+          # a shallow fetch of main can drop the merge base and yield an empty diff.
+          git fetch origin main
           changed=$(git diff --name-only origin/main...HEAD -- 'packages/*' \
             | awk -F/ 'NF>1 {print $2}' | sort -u | jq -R . | jq -sc .)
           echo "packages=$changed" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,7 +1,12 @@
 name: preview-cleanup
 
+# Uses pull_request_target so fork PR closes also have write access to the
+# base repo (the GITHUB_TOKEN for the plain `pull_request` event is read-only
+# on fork PRs regardless of declared permissions). Safe here because we never
+# check out or run PR code -- the job only deletes a ref by a number derived
+# from the trusted event payload.
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - main
@@ -17,9 +22,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Delete preview branch
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          branch="preview/pr-${{ github.event.pull_request.number }}"
+          branch="preview/pr-${PR_NUMBER}"
           if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
             git push origin --delete "$branch"
             echo "Deleted $branch"

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,28 @@
+name: preview-cleanup
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    name: Delete preview branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Delete preview branch
+        run: |
+          set -euo pipefail
+          branch="preview/pr-${{ github.event.pull_request.number }}"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            git push origin --delete "$branch"
+            echo "Deleted $branch"
+          else
+            echo "No preview branch to delete ($branch)"
+          fi

--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -1,0 +1,166 @@
+name: preview-publish
+
+on:
+  workflow_run:
+    workflows: ["preview-build"]
+    types:
+      - completed
+
+# Runs in trusted context (base repo) and consumes the artifact produced by
+# preview-build.yml. Holds the write permissions needed to push the preview
+# branch and edit the PR comment.
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+
+jobs:
+  publish:
+    name: Publish preview & comment
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download preview artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-dist
+          path: preview-dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          pr_number=$(jq -r '.pr_number' preview-dist/metadata.json)
+          head_sha=$(jq -r '.head_sha' preview-dist/metadata.json)
+          changed=$(jq -c '.changed_packages' preview-dist/metadata.json)
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Push preview branch
+        id: push
+        run: |
+          set -euo pipefail
+          branch="preview/pr-${{ steps.meta.outputs.pr_number }}"
+
+          # Move artifact contents outside the worktree before we wipe it.
+          mv preview-dist /tmp/preview-dist
+
+          git config user.name "jspsych-preview-bot"
+          git config user.email "jspsych-preview-bot@users.noreply.github.com"
+
+          # Force-push a fresh orphan branch each run so history stays shallow.
+          git checkout --orphan "$branch"
+          git rm -rf . > /dev/null 2>&1 || true
+          # Defensive cleanup of any untracked leftovers.
+          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+
+          cp -r /tmp/preview-dist/packages .
+          cp /tmp/preview-dist/metadata.json .
+
+          git add packages metadata.json
+          git commit -m "Preview build for PR #${{ steps.meta.outputs.pr_number }} @ ${{ steps.meta.outputs.head_sha }}"
+          git push --force origin "$branch"
+
+          preview_sha=$(git rev-parse HEAD)
+          echo "preview_sha=$preview_sha" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Build comment body
+        env:
+          PREVIEW_SHA: ${{ steps.push.outputs.preview_sha }}
+          PREVIEW_BRANCH: ${{ steps.push.outputs.branch }}
+          PR_HEAD_SHA: ${{ steps.meta.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          CHANGED: ${{ steps.meta.outputs.changed }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          short="${PREVIEW_SHA:0:7}"
+          head_short="${PR_HEAD_SHA:0:7}"
+          base="https://cdn.jsdelivr.net/gh/${REPO}@${PREVIEW_SHA}"
+          src_dir="/tmp/preview-dist"
+
+          # Per-package URLs sourced from what the build actually produced.
+          all_links=""
+          for pkg_dir in "$src_dir"/packages/*/; do
+            name=$(basename "$pkg_dir")
+            pkg_name=$(jq -r '.name // empty' "${pkg_dir}package.json" 2>/dev/null || echo "")
+            [ -z "$pkg_name" ] && pkg_name="$name"
+            if [ -f "${pkg_dir}dist/index.browser.min.js" ]; then
+              all_links+="- \`${pkg_name}\` → \`${base}/packages/${name}/dist/index.browser.min.js\`"$'\n'
+            fi
+          done
+
+          # Quick-start: jspsych core + a sensible plugin (changed plugin if any, else html-keyboard-response).
+          quickstart_plugin=""
+          for pkg in $(echo "$CHANGED" | jq -r '.[]?'); do
+            case "$pkg" in
+              plugin-*)
+                if [ -f "${src_dir}/packages/${pkg}/dist/index.browser.min.js" ]; then
+                  quickstart_plugin="$pkg"
+                  break
+                fi
+                ;;
+            esac
+          done
+          if [ -z "$quickstart_plugin" ] && [ -f "${src_dir}/packages/plugin-html-keyboard-response/dist/index.browser.min.js" ]; then
+            quickstart_plugin="plugin-html-keyboard-response"
+          fi
+
+          {
+            echo '<script src="'"${base}"'/packages/jspsych/dist/index.browser.min.js"></script>'
+            echo '<link rel="stylesheet" href="'"${base}"'/packages/jspsych/css/jspsych.css">'
+            if [ -n "$quickstart_plugin" ]; then
+              echo '<script src="'"${base}"'/packages/'"${quickstart_plugin}"'/dist/index.browser.min.js"></script>'
+            fi
+          } > /tmp/quickstart.html
+
+          changed_md=$(echo "$CHANGED" | jq -r 'if (. // [] | length) == 0 then "_none detected_" else map("`" + . + "`") | join(", ") end')
+          timestamp=$(date -u +'%Y-%m-%d %H:%M UTC')
+
+          {
+            echo '<!-- jspsych-preview-bot -->'
+            echo '### 📦 Preview build ready'
+            echo ''
+            echo "Built from PR head \`${head_short}\` and published at \`${short}\` on branch [\`${PREVIEW_BRANCH}\`](https://github.com/${REPO}/tree/${PREVIEW_BRANCH})."
+            echo 'URLs below are pinned to an immutable commit SHA, so they are safe to share and are cached permanently by jsDelivr.'
+            echo ''
+            echo "**Changed packages:** ${changed_md}"
+            echo ''
+            echo '**Quick-start HTML:**'
+            echo ''
+            echo '```html'
+            cat /tmp/quickstart.html
+            echo '```'
+            echo ''
+            echo '<details><summary>All package URLs</summary>'
+            echo ''
+            echo "$all_links"
+            echo '</details>'
+            echo ''
+            echo "_Last updated ${timestamp} for PR head \`${head_short}\`._"
+          } > comment.md
+
+      - name: Find existing preview comment
+        id: find
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ steps.meta.outputs.pr_number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- jspsych-preview-bot -->'
+
+      - name: Create or update preview comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          issue-number: ${{ steps.meta.outputs.pr_number }}
+          body-path: comment.md
+          edit-mode: replace

--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -25,6 +25,44 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Resolve PR number and head SHA from the trusted workflow_run event payload
+      # rather than the artifact, which is produced by untrusted PR code.
+      # workflow_run.pull_requests is empty for fork PRs, so fall back to the
+      # commits-to-PRs API on head_sha.
+      - name: Resolve trusted PR metadata
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const headSha = context.payload.workflow_run.head_sha;
+            let prNumber = context.payload.workflow_run.pull_requests?.[0]?.number;
+
+            if (!prNumber) {
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: headSha,
+              });
+              const match = prs.find(p => p.head.sha === headSha && p.state === 'open');
+              if (!match) {
+                core.setFailed(`No open PR found for head SHA ${headSha}`);
+                return;
+              }
+              prNumber = match.number;
+            }
+
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid PR number resolved: ${prNumber}`);
+              return;
+            }
+            if (!/^[0-9a-f]{40}$/.test(headSha)) {
+              core.setFailed(`Invalid head SHA from event payload: ${headSha}`);
+              return;
+            }
+
+            core.setOutput('number', String(prNumber));
+            core.setOutput('head_sha', headSha);
+
       - name: Download preview artifact
         uses: actions/download-artifact@v4
         with:
@@ -33,22 +71,43 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Read metadata
+      # Validate the artifact's self-reported metadata against the trusted values
+      # before using anything from it. The `changed` list is sanitized to
+      # `[A-Za-z0-9_-]+` entries so it can't be used for path traversal or shell
+      # injection downstream.
+      - name: Validate artifact metadata
         id: meta
+        env:
+          TRUSTED_PR_NUMBER: ${{ steps.pr.outputs.number }}
+          TRUSTED_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
           set -euo pipefail
-          pr_number=$(jq -r '.pr_number' preview-dist/metadata.json)
-          head_sha=$(jq -r '.head_sha' preview-dist/metadata.json)
-          changed=$(jq -c '.changed_packages' preview-dist/metadata.json)
-          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
-          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          artifact_pr_number=$(jq -r '.pr_number' preview-dist/metadata.json)
+          artifact_head_sha=$(jq -r '.head_sha' preview-dist/metadata.json)
+
+          if [ "$artifact_pr_number" != "$TRUSTED_PR_NUMBER" ]; then
+            echo "Artifact PR number ($artifact_pr_number) does not match trusted ($TRUSTED_PR_NUMBER)" >&2
+            exit 1
+          fi
+          if [ "$artifact_head_sha" != "$TRUSTED_HEAD_SHA" ]; then
+            echo "Artifact head SHA ($artifact_head_sha) does not match trusted ($TRUSTED_HEAD_SHA)" >&2
+            exit 1
+          fi
+
+          changed=$(jq -c '[.changed_packages[]? | select(type == "string" and test("^[A-Za-z0-9_-]+$"))]' preview-dist/metadata.json)
+
+          echo "pr_number=$TRUSTED_PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$TRUSTED_HEAD_SHA" >> "$GITHUB_OUTPUT"
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
       - name: Push preview branch
         id: push
+        env:
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.meta.outputs.head_sha }}
         run: |
           set -euo pipefail
-          branch="preview/pr-${{ steps.meta.outputs.pr_number }}"
+          branch="preview/pr-${PR_NUMBER}"
 
           # Move artifact contents outside the worktree before we wipe it.
           mv preview-dist /tmp/preview-dist
@@ -66,7 +125,7 @@ jobs:
           cp /tmp/preview-dist/metadata.json .
 
           git add packages metadata.json
-          git commit -m "Preview build for PR #${{ steps.meta.outputs.pr_number }} @ ${{ steps.meta.outputs.head_sha }}"
+          git commit -m "Preview build for PR #${PR_NUMBER} @ ${HEAD_SHA}"
           git push --force origin "$branch"
 
           preview_sha=$(git rev-parse HEAD)
@@ -89,11 +148,18 @@ jobs:
           src_dir="/tmp/preview-dist"
 
           # Per-package URLs sourced from what the build actually produced.
+          # Skip any directory whose name doesn't match a known-safe pattern, since
+          # the artifact ultimately comes from untrusted PR code.
           all_links=""
           for pkg_dir in "$src_dir"/packages/*/; do
             name=$(basename "$pkg_dir")
+            if ! [[ "$name" =~ ^[A-Za-z0-9_-]+$ ]]; then
+              continue
+            fi
             pkg_name=$(jq -r '.name // empty' "${pkg_dir}package.json" 2>/dev/null || echo "")
-            [ -z "$pkg_name" ] && pkg_name="$name"
+            if ! [[ "$pkg_name" =~ ^@?[A-Za-z0-9_/-]+$ ]]; then
+              pkg_name="$name"
+            fi
             if [ -f "${pkg_dir}dist/index.browser.min.js" ]; then
               all_links+="- \`${pkg_name}\` → \`${base}/packages/${name}/dist/index.browser.min.js\`"$'\n'
             fi

--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -11,7 +11,7 @@ on:
 # branch and edit the PR comment.
 permissions:
   contents: write
-  pull-requests: write
+  pull-requests: read
   issues: write
   actions: read
 
@@ -60,10 +60,27 @@ jobs:
               return;
             }
 
+            // Guard against the close/build race: if the PR was closed while
+            // preview-build was running, preview-cleanup may have already deleted
+            // the preview branch. Re-creating it here would orphan a branch with
+            // no further cleanup trigger.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            if (pr.state !== 'open') {
+              core.notice(`PR #${prNumber} is ${pr.state}; skipping preview publish.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            core.setOutput('skip', 'false');
             core.setOutput('number', String(prNumber));
             core.setOutput('head_sha', headSha);
 
       - name: Download preview artifact
+        if: steps.pr.outputs.skip != 'true'
         uses: actions/download-artifact@v4
         with:
           name: preview-dist
@@ -71,11 +88,26 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
+      # The artifact comes from untrusted PR code. `cp -r` follows symlinks by
+      # default, so a symlink in the artifact tree could exfiltrate runner-local
+      # files into the preview branch (which jsDelivr will publish). Refuse any
+      # symlink rather than trying to handle it safely.
+      - name: Reject symlinks in artifact
+        if: steps.pr.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          if find preview-dist -type l -print -quit | grep -q .; then
+            echo "Refusing artifact: contains symlinks" >&2
+            find preview-dist -type l >&2
+            exit 1
+          fi
+
       # Validate the artifact's self-reported metadata against the trusted values
       # before using anything from it. The `changed` list is sanitized to
       # `[A-Za-z0-9_-]+` entries so it can't be used for path traversal or shell
       # injection downstream.
       - name: Validate artifact metadata
+        if: steps.pr.outputs.skip != 'true'
         id: meta
         env:
           TRUSTED_PR_NUMBER: ${{ steps.pr.outputs.number }}
@@ -101,6 +133,7 @@ jobs:
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
       - name: Push preview branch
+        if: steps.pr.outputs.skip != 'true'
         id: push
         env:
           PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
@@ -133,6 +166,7 @@ jobs:
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
       - name: Build comment body
+        if: steps.pr.outputs.skip != 'true'
         env:
           PREVIEW_SHA: ${{ steps.push.outputs.preview_sha }}
           PREVIEW_BRANCH: ${{ steps.push.outputs.branch }}
@@ -216,6 +250,7 @@ jobs:
           } > comment.md
 
       - name: Find existing preview comment
+        if: steps.pr.outputs.skip != 'true'
         id: find
         uses: peter-evans/find-comment@v3
         with:
@@ -224,6 +259,7 @@ jobs:
           body-includes: '<!-- jspsych-preview-bot -->'
 
       - name: Create or update preview comment
+        if: steps.pr.outputs.skip != 'true'
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.find.outputs.comment-id }}


### PR DESCRIPTION
## Summary

Adds three workflows that publish a CDN-accessible preview build for every PR against `main`, so contributors and reviewers can spin up a static site that points at a branch's exact build via jsDelivr.

- **`preview-build.yml`** — `pull_request` trigger. Builds all packages, stages `packages/*/dist` + `css` + `package.json` into a `preview-dist/` tree, computes the changed-package list from `git diff origin/main...HEAD`, and uploads the result as an artifact. Runs in untrusted context (`permissions: contents: read`, no secrets), so fork PRs are safe.
- **`preview-publish.yml`** — `workflow_run` trigger after `preview-build` succeeds. Downloads the artifact, force-pushes a fresh orphan `preview/pr-<number>` branch with the staged dist, then creates or updates a single PR comment with `cdn.jsdelivr.net/gh/jspsych/jsPsych@<sha>/...` URLs pinned to the new commit SHA. The comment is found/edited via a hidden `<!-- jspsych-preview-bot -->` marker, so subsequent commits on the PR edit the comment in place rather than spamming new ones.
- **`preview-cleanup.yml`** — `pull_request: closed` trigger. Deletes `preview/pr-<num>` once the PR is merged or closed.

URLs are pinned to immutable commit SHAs, so jsDelivr's edge cache never needs to be purged.

## Design notes

- **Two-workflow split** is the standard "Dependabot-safe" pattern: the `pull_request` job has no write access, the trusted `workflow_run` job is the only thing that touches the repo or comments on PRs.
- **Per-PR orphan branches** keep the main repo's history clean — each push force-pushes a single-commit branch, and the cleanup workflow removes it on close.
- **Comment editing** uses `peter-evans/find-comment@v3` + `peter-evans/create-or-update-comment@v4`, both already common in the GitHub Actions ecosystem (the repo already uses external actions like `changesets/action` so this matches existing convention).

## Dry-run caveat

`workflow_run` workflows only fire when the workflow file is on the default branch, so `preview-publish.yml` **will not run from this PR** — only `preview-build.yml` will execute against the PR head. The end-to-end flow (preview branch push + PR comment) can only be verified after this lands on `main`. Marking this as draft for that reason.

## Test plan

- [ ] Confirm `preview-build` runs on this PR and produces a `preview-dist` artifact containing `packages/jspsych/dist/index.browser.min.js`, `packages/jspsych/css/jspsych.css`, plugin bundles, and `metadata.json`.
- [ ] After merge: open a follow-up PR touching a single plugin's `src/` and confirm:
  - [ ] `preview-publish` fires and force-pushes `preview/pr-<num>`
  - [ ] A bot comment appears with quick-start HTML and the SHA-pinned URLs
  - [ ] The URLs actually load via `https://cdn.jsdelivr.net/gh/jspsych/jsPsych@<sha>/...`
  - [ ] A second push to the PR edits the existing comment (no duplicate)
  - [ ] Closing the PR triggers `preview-cleanup` and deletes the branch
- [ ] Verify with a fork PR that the build half succeeds (no secrets needed) and the publish half still runs in the trusted context.

https://claude.ai/code/session_0169ryzSFBbyzF62P7dQ1UYW

---
_Generated by [Claude Code](https://claude.ai/code/session_0169ryzSFBbyzF62P7dQ1UYW)_