### PR TITLE
ci(preview): grant pull-requests:write so PR comment posts

### DIFF
--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -11,7 +11,11 @@ on:
 # branch and edit the PR comment.
 permissions:
   contents: write
-  pull-requests: read
+  # `pull-requests: write` is required (despite PR comments using the issues
+  # API endpoint) because GitHub Actions enforces PR-targeted writes against
+  # the `pull-requests` scope. Without this, peter-evans/create-or-update-comment
+  # silently no-ops on PRs.
+  pull-requests: write
   issues: write
   actions: read
 


### PR DESCRIPTION
## Summary

Fixes the preview-publish workflow silently failing to post the per-PR comment after #3662 landed.

## What's broken

On PR #3661, `preview-build` succeeded and `preview-publish` ran far enough to push the orphan `preview/pr-3661` branch with valid `metadata.json` — but no comment ever appeared on the PR.

## Root cause

`peter-evans/create-or-update-comment@v4` uses the issues API endpoint (`POST /repos/{owner}/{repo}/issues/{n}/comments`) to post general PR comments. The earlier permissions block reasoned, correctly at the API level, that this only needs `issues: write`. But GitHub Actions adds an additional layer on top: it enforces a separate `pull-requests` scope for any write that *targets* a pull request, regardless of which underlying API endpoint the action calls.

With `pull-requests: read`, the action's POST gets silently no-op'd on PRs. The job logs as successful, the preview branch is published, no comment is created.

## Fix

One-line permission bump from `read` to `write`, with an inline comment explaining why this is necessary despite the issues-API rationale.

```diff
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
   issues: write
   actions: read
```

## Test plan

- [ ] Merge this PR, then re-trigger `preview-build` on an open PR (e.g. by pushing any commit to PR #3661). The `preview-publish` workflow should post a comment with the jsDelivr URLs.
- [ ] Confirm subsequent pushes update the existing comment in place rather than appending a new one (`find-comment` looks up by `<!-- jspsych-preview-bot -->`).

https://claude.ai/code/session_01WCetXEmRj6Y2cBVsvYz7vM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCetXEmRj6Y2cBVsvYz7vM)_