### PR TITLE
fix(docs): use main.html override so Algolia meta tag reaches deployed site

### DIFF
--- a/overrides/index.html
+++ b/overrides/index.html
@@ -1,5 +1,0 @@
-{% extends "index.html" %}
-
-{% block extrahead %}
-  <meta name="algolia-site-verification"  content="4B994F893596449E" />
-{% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  <meta name="algolia-site-verification" content="4B994F893596449E" />
+{% endblock %}


### PR DESCRIPTION
## Summary

Follow-up to #3664. After that PR was merged and `Publish Docs` was run, the Algolia verification meta tag was not present on the deployed site.

**Root cause:** Material for MkDocs renders normal documentation pages through `main.html` (which extends `base.html`). The override added in #3664 was named `overrides/index.html` and `{% extends "index.html" %}`, but Material's `index.html` template is only used for pages that explicitly opt in via `template: index.html` in YAML front matter. None of the jsPsych docs pages do this, so the override was never instantiated and `extrahead` was never injected.

**Fix:** Rename the override to `overrides/main.html` and extend `base.html`, per the Material customization recipe (https://squidfunk.github.io/mkdocs-material/customization/#extending-the-theme). Also collapsed the stray double space between attributes in the `<meta>` tag.

`mkdocs.yml` already has the correct `theme.custom_dir: 'overrides'` from #3664 and is unchanged here.

## Test plan

- [ ] Re-run the `Publish Docs` GitHub Action against this branch (or after merge to `main`).
- [ ] View source on https://www.jspsych.org/ and confirm `<meta name="algolia-site-verification" content="4B994F893596449E" />` is present in `<head>`.
- [ ] Spot-check a deeper page (e.g. a plugin reference page) to confirm the tag is site-wide, not just on the homepage.
- [ ] Trigger Algolia DocSearch verification from the dashboard.

https://claude.ai/code/session_01V5YbstVEoGn4g1nZhgJ9Fy

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5YbstVEoGn4g1nZhgJ9Fy)_