### PR TITLE
chore: update prettier to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "husky": "^8.0.3",
         "import-sort-style-module": "^6.0.0",
         "lint-staged": "^13.0.3",
-        "prettier": "^2.7.1",
+        "prettier": "^3.8.3",
         "prettier-plugin-import-sort": "^0.0.7",
         "turbo": "^1.6.3"
       },
@@ -800,6 +800,22 @@
       "integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
       "dev": true
     },
+    "node_modules/@changesets/apply-release-plan/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@changesets/assemble-release-plan": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.5.tgz",
@@ -1091,6 +1107,22 @@
       "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.0.0.tgz",
       "integrity": "sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==",
       "dev": true
+    },
+    "node_modules/@changesets/write/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/@citation-js/core": {
       "version": "0.7.18",
@@ -10681,15 +10713,16 @@
       "dev": true
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "husky": "^8.0.3",
     "import-sort-style-module": "^6.0.0",
     "lint-staged": "^13.0.3",
-    "prettier": "^2.7.1",
+    "prettier": "^3.8.3",
     "prettier-plugin-import-sort": "^0.0.7",
     "turbo": "^1.6.3"
   },


### PR DESCRIPTION
Summary:
- Updates Prettier from v2.8.8 to v3.8.3.
- Leaves existing formatting unchanged.
- Keeps existing root package.json Prettier config: printWidth 100.
- Keeps existing lint-staged behavior: prettier --write for staged TS/JS/MJS/CJS files.

Important note:
This is not a formatting cleanup PR. It only updates the Prettier dependency. A full Prettier formatting pass was intentionally not run because the repo already has a noisy formatting baseline, and running `prettier --write` would create a large formatting-only diff.

Verification:
- `npx prettier@2.8.8 --check [sample files]` showed the same sample files already had formatting issues before Prettier 3.
- `npm test -- --watch=false` passed:
  - 79 test suites passed
  - 670 tests passed
  - 6 skipped
  - 10 snapshots passed.
- `npx prettier --check "packages/**/*.{ts,js,mjs,cjs}" --ignore-path .gitignore` still reports existing formatting issues, so no formatting changes were included.