### PR TITLE
chore: update open sans font package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1613,10 +1613,14 @@
       }
     },
     "node_modules/@fontsource/open-sans": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/@fontsource/open-sans/-/open-sans-4.5.3.tgz",
-      "integrity": "sha512-zabYpvz2XkZ4Vp1EN2/k0r5X9kQgwjdj1+kJ6B0T/oN4h9yqJqr9VKxa+JspRxClxDEo23K5GqfuIEH1+WyFOw==",
-      "dev": true
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/open-sans/-/open-sans-5.2.7.tgz",
+      "integrity": "sha512-8yfgDYjE5O0vmTPdrcjV35y4yMnctsokmi9gN49Gcsr0sjzkMkR97AnKDe6OqZh2SFkYlR28fxOvi21bYEgMSw==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@gulpjs/messages": {
       "version": "1.1.0",
@@ -14144,7 +14148,7 @@
         "type-fest": "^2.9.0"
       },
       "devDependencies": {
-        "@fontsource/open-sans": "4.5.3",
+        "@fontsource/open-sans": "5.2.7",
         "@jspsych/config": "^3.3.0",
         "@types/dom-mediacapture-record": "^1.0.11",
         "base64-inline-loader": "^2.0.1",

--- a/packages/jspsych/package.json
+++ b/packages/jspsych/package.json
@@ -47,7 +47,7 @@
     "type-fest": "^2.9.0"
   },
   "devDependencies": {
-    "@fontsource/open-sans": "4.5.3",
+    "@fontsource/open-sans": "5.2.7",
     "@jspsych/config": "^3.3.0",
     "@types/dom-mediacapture-record": "^1.0.11",
     "base64-inline-loader": "^2.0.1",


### PR DESCRIPTION
  ## Summary
  - Updates `@fontsource/open-sans` in `packages/jspsych` from `4.5.3` to `5.2.7`
  - Leaves existing SCSS import paths unchanged because v5 still provides the imported CSS files

  ## Verification
  - npm run build:styles --workspace=packages/jspsych
  - npm run build --workspace=packages/jspsych
  - npm test --workspace=packages/jspsych