### PR TITLE
chore: update webpack remove empty scripts plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3981,16 +3981,13 @@
       }
     },
     "node_modules/ansis": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-1.5.6.tgz",
-      "integrity": "sha512-vKn0k5V0oiaOClcUMNDFb7DvI3+asAozhg1wI8bLkYxV0lhfPtIuwjUa1wG9/YaUY/KwO9U2B7m0FMqzn/jXUQ==",
+      "version": "4.0.0-node10",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.0.0-node10.tgz",
+      "integrity": "sha512-BRrU0Bo1X9dFGw6KgGz6hWrqQuOlVEDOzkb0QSLZY9sXHqA7pNj7yHPVJRz7y/rj4EOJ3d/D5uxH+ee9leYgsg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://patreon.com/biodiscus"
+        "node": ">=10"
       }
     },
     "node_modules/any-promise": {
@@ -13350,12 +13347,13 @@
       }
     },
     "node_modules/webpack-remove-empty-scripts": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/webpack-remove-empty-scripts/-/webpack-remove-empty-scripts-0.7.3.tgz",
-      "integrity": "sha512-yipqb25A0qtH7X9vKt6yihwyYkTtSlRiDdBb2QsyrkqGM3hpfAcfOO1lYDef9HQUNm3s8ojmorbNg32XXX6FYg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webpack-remove-empty-scripts/-/webpack-remove-empty-scripts-1.1.1.tgz",
+      "integrity": "sha512-FqmIy7joxXd0/7jz8UjzMXOKc6B7LR+ynfgaaaH72xUT917h3A94ERxOLvGM8a8XdGIvUsdTLIUt8aBQM2Pdqg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "ansis": "^1.3.4"
+        "ansis": "4.0.0-node10"
       },
       "engines": {
         "node": ">=12.14"
@@ -14156,7 +14154,7 @@
         "sass-loader": "^12.4.0",
         "webpack": "^5.76.0",
         "webpack-cli": "^4.9.2",
-        "webpack-remove-empty-scripts": "^0.7.2"
+        "webpack-remove-empty-scripts": "^1.1.1"
       }
     },
     "packages/jspsych/node_modules/@jspsych/config": {

--- a/packages/jspsych/package.json
+++ b/packages/jspsych/package.json
@@ -59,6 +59,6 @@
     "sass-loader": "^12.4.0",
     "webpack": "^5.76.0",
     "webpack-cli": "^4.9.2",
-    "webpack-remove-empty-scripts": "^0.7.2"
+    "webpack-remove-empty-scripts": "^1.1.1"
   }
 }


### PR DESCRIPTION
  ## Summary
  - Updates `webpack-remove-empty-scripts` in `packages/jspsych` from `^0.7.2` / locked `0.7.3` to `^1.1.1`
  - Keeps the existing Webpack config unchanged because the CommonJS import and no-argument plugin usage remain
  compatible

  ## Verification
  - npm run build:styles --workspace=packages/jspsych
  - npm run build --workspace=packages/jspsych
  - npm test --workspace=packages/jspsych