### PR TITLE
Deps/rollup node resolve 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3981,16 +3981,13 @@
       }
     },
     "node_modules/ansis": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-1.5.6.tgz",
-      "integrity": "sha512-vKn0k5V0oiaOClcUMNDFb7DvI3+asAozhg1wI8bLkYxV0lhfPtIuwjUa1wG9/YaUY/KwO9U2B7m0FMqzn/jXUQ==",
+      "version": "4.0.0-node10",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.0.0-node10.tgz",
+      "integrity": "sha512-BRrU0Bo1X9dFGw6KgGz6hWrqQuOlVEDOzkb0QSLZY9sXHqA7pNj7yHPVJRz7y/rj4EOJ3d/D5uxH+ee9leYgsg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://patreon.com/biodiscus"
+        "node": ">=10"
       }
     },
     "node_modules/any-promise": {
@@ -13350,12 +13347,13 @@
       }
     },
     "node_modules/webpack-remove-empty-scripts": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/webpack-remove-empty-scripts/-/webpack-remove-empty-scripts-0.7.3.tgz",
-      "integrity": "sha512-yipqb25A0qtH7X9vKt6yihwyYkTtSlRiDdBb2QsyrkqGM3hpfAcfOO1lYDef9HQUNm3s8ojmorbNg32XXX6FYg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webpack-remove-empty-scripts/-/webpack-remove-empty-scripts-1.1.1.tgz",
+      "integrity": "sha512-FqmIy7joxXd0/7jz8UjzMXOKc6B7LR+ynfgaaaH72xUT917h3A94ERxOLvGM8a8XdGIvUsdTLIUt8aBQM2Pdqg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "ansis": "^1.3.4"
+        "ansis": "4.0.0-node10"
       },
       "engines": {
         "node": ">=12.14"
@@ -14156,7 +14154,7 @@
         "sass-loader": "^12.4.0",
         "webpack": "^5.76.0",
         "webpack-cli": "^4.9.2",
-        "webpack-remove-empty-scripts": "^0.7.2"
+        "webpack-remove-empty-scripts": "^1.1.1"
       }
     },
     "packages/jspsych/node_modules/@jspsych/config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2978,6 +2978,7 @@
       "version": "15.2.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
       "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
+      "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
         "@types/resolve": "1.20.2",
@@ -4559,6 +4560,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -7425,6 +7427,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
       "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
       "dependencies": {
         "builtin-modules": "^3.3.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13767,7 +13767,7 @@
         "@citation-js/plugin-csl": "^0.7.14",
         "@citation-js/plugin-software-formats": "^0.6.1",
         "@rollup/plugin-commonjs": "26.0.1",
-        "@rollup/plugin-node-resolve": "15.2.3",
+        "@rollup/plugin-node-resolve": "16.0.3",
         "@rollup/plugin-replace": "^6.0.1",
         "@sucrase/jest-plugin": "3.0.0",
         "@types/gulp": "4.0.17",
@@ -13797,6 +13797,30 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/config/node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "packages/config/node_modules/@rollup/rollup-android-arm-eabi": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -44,7 +44,7 @@
     "@citation-js/plugin-csl": "^0.7.14",
     "@citation-js/plugin-software-formats": "^0.6.1",
     "@rollup/plugin-commonjs": "26.0.1",
-    "@rollup/plugin-node-resolve": "15.2.3",
+    "@rollup/plugin-node-resolve": "16.0.3",
     "@rollup/plugin-replace": "^6.0.1",
     "@sucrase/jest-plugin": "3.0.0",
     "@types/gulp": "4.0.17",

--- a/packages/jspsych/package.json
+++ b/packages/jspsych/package.json
@@ -59,6 +59,6 @@
     "sass-loader": "^12.4.0",
     "webpack": "^5.76.0",
     "webpack-cli": "^4.9.2",
-    "webpack-remove-empty-scripts": "^0.7.2"
+    "webpack-remove-empty-scripts": "^1.1.1"
   }
 }


### PR DESCRIPTION
## Summary
  - Update `@rollup/plugin-node-resolve` in `packages/config` from `15.2.3` to `16.0.3`
  - Leave shared Rollup config unchanged because current `resolve({ preferBuiltins: false })` usage is compatible

  ## Verification
  - `npm run build --workspace=packages/config` unavailable: missing `build` script
  - `npm run build --workspace=packages/jspsych`
  - `npm test --workspace=packages/config`
  - `npm test --workspace=packages/jspsych`
  - `npm install --package-lock-only` was run after the update to confirm the lockfile is synced.

  ## Notes
  - `npm run build` is blocked locally by Turbo TLS/keychain setup: “No keychain is available”