### PR TITLE
docs: fix response field description in survey plugins

### DIFF
--- a/.changeset/fix-survey-response-jsdoc.md
+++ b/.changeset/fix-survey-response-jsdoc.md
@@ -1,0 +1,7 @@
+---
+"@jspsych/plugin-survey-text": patch
+"@jspsych/plugin-survey-multi-choice": patch
+"@jspsych/plugin-survey-multi-select": patch
+---
+
+Fix the `response` data field description, which was copied from the survey-likert plugin and incorrectly described responses as integers representing a position on a likert scale. The description now reflects what each plugin actually records: the entered text (survey-text), the selected option (survey-multi-choice), and the selected option(s) (survey-multi-select).

--- a/packages/plugin-survey-multi-choice/src/index.ts
+++ b/packages/plugin-survey-multi-choice/src/index.ts
@@ -78,7 +78,7 @@ const info = <const>{
     },
   },
   data: {
-    /** An object containing the response for each question. The object will have a separate key (variable) for each question, with the first question in the trial being recorded in `Q0`, the second in `Q1`, and so on. The responses are recorded as integers, representing the position selected on the likert scale for that question. If the `name` parameter is defined for the question, then the response object will use the value of `name` as the key for each question. This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions. */
+    /** An object containing the response for each question. The object will have a separate key (variable) for each question, with the first question in the trial being recorded in `Q0`, the second in `Q1`, and so on. For each question, the response is a string containing the option that the participant selected. If the `name` parameter is defined for the question, then the response object will use the value of `name` as the key for each question. This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions. */
     response: {
       type: ParameterType.OBJECT,
     },

--- a/packages/plugin-survey-multi-select/src/index.ts
+++ b/packages/plugin-survey-multi-select/src/index.ts
@@ -83,7 +83,7 @@ const info = <const>{
   },
 
   data: {
-    /** An object containing the response for each question. The object will have a separate key (variable) for each question, with the first question in the trial being recorded in `Q0`, the second in `Q1`, and so on. The responses are recorded as integers, representing the position selected on the likert scale for that question. If the `name` parameter is defined for the question, then the response object will use the value of `name` as the key for each question. This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions. */
+    /** An object containing the response for each question. The object will have a separate key (variable) for each question, with the first question in the trial being recorded in `Q0`, the second in `Q1`, and so on. For each question, the response is an array containing the option(s) that the participant selected. If the `name` parameter is defined for the question, then the response object will use the value of `name` as the key for each question. This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions. */
     response: {
       type: ParameterType.OBJECT,
     },

--- a/packages/plugin-survey-text/src/index.ts
+++ b/packages/plugin-survey-text/src/index.ts
@@ -81,7 +81,7 @@ const info = <const>{
     },
   },
   data: {
-    /** An object containing the response for each question. The object will have a separate key (variable) for each question, with the first question in the trial being recorded in `Q0`, the second in `Q1`, and so on. The responses are recorded as integers, representing the position selected on the likert scale for that question. If the `name` parameter is defined for the question, then the response object will use the value of `name` as the key for each question. This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions. */
+    /** An object containing the response for each question. The object will have a separate key (variable) for each question, with the first question in the trial being recorded in `Q0`, the second in `Q1`, and so on. For each question, the response is a string containing the text the participant entered into the response box. If the `name` parameter is defined for the question, then the response object will use the value of `name` as the key for each question. This will be encoded as a JSON string when data is saved using the `.json()` or `.csv()` functions. */
     response: {
       type: ParameterType.OBJECT,
     },


### PR DESCRIPTION
## Summary

The `response` data field's JSDoc in three survey plugins — `@jspsych/plugin-survey-text`, `@jspsych/plugin-survey-multi-choice`, and `@jspsych/plugin-survey-multi-select` — was copied verbatim from `survey-likert`. It incorrectly states that responses are *"recorded as integers, representing the position selected on the likert scale."* That is only true for `survey-likert`; these plugins record text or selected option(s), not likert integers.

This propagates into anything that reads the plugin JSDoc for documentation (e.g. auto-generated dataset metadata), producing descriptions that contradict the actual data.

## Changes

Replaced only the incorrect sentence in each plugin's `response` description with what the plugin actually records:

| Plugin | `response` now described as |
|---|---|
| `survey-text` | a string containing the text the participant entered |
| `survey-multi-choice` | a string containing the option that was selected |
| `survey-multi-select` | an array containing the option(s) that were selected |

The rest of each description (the `Q0`/`Q1` naming, the `name` parameter behavior, the JSON-string encoding note) is unchanged.

A changeset is included with `patch` bumps for all three packages.

## Notes

Docs-only change; no runtime behavior is affected.