### PR TITLE
Fix preview-publish PR lookup for fork PRs

### DIFF
--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -42,14 +42,26 @@ jobs:
             let prNumber = context.payload.workflow_run.pull_requests?.[0]?.number;
 
             if (!prNumber) {
-              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              // workflow_run.pull_requests is empty for fork PRs. The
+              // commits-to-PRs API (listPullRequestsAssociatedWithCommit) also
+              // returns nothing for fork-PR head commits, since they don't live
+              // in a base-repo branch. Look the PR up by its head ref instead,
+              // using the head repo + branch from the trusted event payload.
+              const headOwner = context.payload.workflow_run.head_repository?.owner?.login;
+              const headBranch = context.payload.workflow_run.head_branch;
+              if (!headOwner || !headBranch) {
+                core.setFailed(`Missing head repository/branch in workflow_run payload for head SHA ${headSha}`);
+                return;
+              }
+              const { data: prs } = await github.rest.pulls.list({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                commit_sha: headSha,
+                state: 'open',
+                head: `${headOwner}:${headBranch}`,
               });
-              const match = prs.find(p => p.head.sha === headSha && p.state === 'open');
+              const match = prs.find(p => p.head.sha === headSha);
               if (!match) {
-                core.setFailed(`No open PR found for head SHA ${headSha}`);
+                core.setFailed(`No open PR found for ${headOwner}:${headBranch} at head SHA ${headSha}`);
                 return;
               }
               prNumber = match.number;


### PR DESCRIPTION
## Problem

Fork PRs (e.g. #3694) never receive a preview-build comment. The `preview-build` workflow succeeds and uploads the artifact, but the companion `preview-publish` workflow — which runs in the trusted base-repo context and is responsible for pushing the preview branch and posting the comment — fails early:

```
##[error]No open PR found for head SHA b57950b961b6cf7e4d6a1c2ba8f515e7a582a3a4
```

## Root cause

For fork PRs, `workflow_run.pull_requests` is empty (as the workflow already anticipates), so it falls back to `listPullRequestsAssociatedWithCommit`. But that endpoint returns `[]` for a fork-PR head commit, because the commit doesn't live in a base-repo branch — only under `refs/pull/N/head`. With no match, the step calls `core.setFailed(...)` and the job dies before commenting.

Verified directly against the API for #3694's head SHA:

```
repos/jspsych/jsPsych/commits/b57950b.../pulls  ->  []
```

## Fix

Look the PR up by its head ref (`headOwner:headBranch`) — both taken from the trusted `workflow_run` payload — via `pulls.list`. This resolves the PR where the previous approach returned nothing:

```
pulls?state=open&head=htsukamoto5:multiplayer  ->  { number: 3694, head_sha: b57950b..., state: open }
```

Trust guarantees are unchanged: the PR number and head SHA are still sourced only from the trusted event payload and validated downstream (the artifact's self-reported SHA/number are still cross-checked against these values). Same-repo PRs are unaffected — they populate `workflow_run.pull_requests` and never hit the fallback. A stale build (head moved after the build started) still correctly fails, since the match requires `p.head.sha === headSha`.

## Verification note

`workflow_run` always runs the workflow version on the base branch, so this can only be fully validated after merge: once on `main`, retriggering `preview-build` on a fork PR (e.g. push a commit to #3694) should make the publish job resolve the PR and post the preview comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)