### PR TITLE
ci: add CodeQL static analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '30 3 * * 4'
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript-typescript' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/codeql.yml` running CodeQL's `javascript-typescript` analysis on push to `main`, on PRs into `main`, and on a weekly schedule.
- Fixes the OpenSSF Scorecard **SAST** check, currently scoring 0 ("0 commits out of 30 are checked with a SAST tool").
- Actions are pinned by commit SHA from the start (`actions/checkout` and `github/codeql-action/*` at their current latest release), so this doesn't add new unpinned-dependency findings.

## Test plan
- [x] Confirm the workflow runs successfully on this PR and results show up under the Security → Code scanning tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)