### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
         node: [18, 20]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -33,7 +33,7 @@ jobs:
 
       # Running this after `npm ci` because `npm ci` removes `node_modules`:
       - name: Download Turborepo cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: node_modules/.cache/turbo
           key: ${{ runner.os }}-node-${{ matrix.node }}-turbo-${{ hashFiles('node_modules/.cache/turbo') }}

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -15,12 +15,12 @@ jobs:
     name: Build preview dist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: npm
@@ -67,7 +67,7 @@ jobs:
           }
           EOF
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: preview-dist
           path: preview-dist/

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -19,7 +19,7 @@ jobs:
     name: Delete preview branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Delete preview branch
         env:

--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
       # commits-to-PRs API on head_sha.
       - name: Resolve trusted PR metadata
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const headSha = context.payload.workflow_run.head_sha;
@@ -97,7 +97,7 @@ jobs:
 
       - name: Download preview artifact
         if: steps.pr.outputs.skip != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: preview-dist
           path: preview-dist
@@ -268,7 +268,7 @@ jobs:
       - name: Find existing preview comment
         if: steps.pr.outputs.skip != 'true'
         id: find
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         with:
           issue-number: ${{ steps.meta.outputs.pr_number }}
           comment-author: 'github-actions[bot]'
@@ -276,7 +276,7 @@ jobs:
 
       - name: Create or update preview comment
         if: steps.pr.outputs.skip != 'true'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.find.outputs.comment-id }}
           issue-number: ${{ steps.meta.outputs.pr_number }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -9,17 +9,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.8'
 
@@ -42,9 +42,6 @@ jobs:
         run: git checkout gh-pages
 
       - name: Push gh-pages branch
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
+        run: git push origin gh-pages
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 20
           cache: npm
@@ -28,7 +28,7 @@ jobs:
         run: npm ci
 
       - name: Download Turborepo cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: node_modules/.cache/turbo
           key: ${{ runner.os }}-node-20-turbo-${{ hashFiles('node_modules/.cache/turbo') }}
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish Packages
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: npm run changeset:version
           publish: npm run changeset:publish
@@ -59,7 +59,7 @@ jobs:
         run: npm run build:archive
 
       - name: Upload Release Assets
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3.37.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Pins every tag-referenced Action across `.github/workflows/*.yml` to its current release commit SHA (version kept as a trailing comment, e.g. `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2`). No version bumps — same releases that were already running, just no longer re-targetable by a tag push.
- Replaces `ad-m/github-push-action@master` in `publish-docs.yml` with a plain `git push origin gh-pages`. That step was using a **mutable branch ref** (not even a tag) on a third-party action, which is a bigger supply-chain risk than an unpinned tag — and unnecessary, since `actions/checkout`'s default `persist-credentials: true` already leaves a push-capable `GITHUB_TOKEN` credential configured.
- Fixes the OpenSSF Scorecard **Pinned-Dependencies** check, currently scoring 3/10 ("2 out of 20 GitHub-owned, 1 out of 5 third-party Actions pinned").

## Notes
- SHAs were resolved via `gh api repos/<owner>/<repo>/commits/<tag>` and spot-checked against the equivalent full-semver tag to confirm they match.
- Some pinned actions (`actions/checkout@v3`, `actions/setup-node@v3`) are older majors already in use elsewhere in this repo; this PR keeps them as-is rather than bundling a version bump. Worth a follow-up separately.

## Test plan
- [x] Confirm `build` and `preview-build`/`preview-publish` still run successfully on this PR (no version changes, so behavior should be identical).
- [ ] After merge, confirm the next docs deploy (`publish-docs.yml`) can still push to `gh-pages` with the plain `git push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)