### PR TITLE
ci(release): attach build provenance attestations to release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Needed by actions/attest-build-provenance to mint a Sigstore signing
+      # cert from the workflow's OIDC identity and to record the attestation.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -61,8 +65,21 @@ jobs:
       - name: Pack Dist Archive
         run: npm run build:archive
 
+      # Generates a SLSA build provenance attestation for dist.zip, signed
+      # keylessly via Sigstore using this workflow run's OIDC identity. The
+      # bundle is uploaded as a release asset below so downloads can be
+      # verified back to this exact commit and workflow run, e.g. with
+      # `gh attestation verify jspsych.zip --owner jspsych`.
+      - name: Attest build provenance
+        id: attest
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: dist.zip
+
       - name: Upload Release Assets
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          ATTESTATION_BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
         with:
           script: |
             const fs = require("fs");
@@ -70,6 +87,8 @@ jobs:
             const { owner, repo } = context.repo;
             const distFile = "dist.zip";
             const assetName = "jspsych.zip";
+            const attestationFile = process.env.ATTESTATION_BUNDLE_PATH;
+            const attestationAssetName = `${assetName}.intoto.jsonl`;
 
             /**
             * Returns all recent releases without a dist archive asset, up to (excluding) the first release
@@ -107,6 +126,13 @@ jobs:
             const distFileSize = fs.statSync(distFile).size;
             const distFileContents = fs.readFileSync(distFile);
 
+            const attestationContents = attestationFile && fs.existsSync(attestationFile)
+              ? fs.readFileSync(attestationFile)
+              : null;
+            if (!attestationContents) {
+              console.log("No attestation bundle found; uploading dist archive without provenance.");
+            }
+
             // Upload dist archive for each release without a dist archive, in reverse order so re-running an
             // aborted or failed job will pick up where it left off last time
             for (const release of releasesWithoutDistArchive.reverse()) {
@@ -125,4 +151,20 @@ jobs:
                 },
                 data: distFileContents,
               });
+
+              if (attestationContents) {
+                console.log(`Uploading build provenance attestation for ${release.tag_name}`);
+                await github.rest.repos.uploadReleaseAsset({
+                  owner,
+                  repo,
+                  release_id: release.id,
+                  name: attestationAssetName,
+                  label: "Build provenance attestation (SLSA)",
+                  headers: {
+                    "content-type": "application/json",
+                    "content-length": attestationContents.length,
+                  },
+                  data: attestationContents,
+                });
+              }
             }


### PR DESCRIPTION
## Summary
- Stacked on #3701 (job-level permissions) since both touch `release.yml`'s `permissions:` block — review/merge that one first, then rebase this if needed.
- Adds `actions/attest-build-provenance` right after `Pack Dist Archive`, generating a SLSA build provenance attestation for `dist.zip`. This is signed keylessly via Sigstore, using the workflow run's GitHub OIDC identity — no long-lived signing key to manage or leak.
- The attestation bundle is uploaded as `jspsych.zip.intoto.jsonl` alongside the existing `jspsych.zip` asset, reusing the existing backfill loop (so both new releases and any past releases still missing the dist archive get the attestation too).
- Adds `id-token: write` and `attestations: write` to the job's permissions (required by the attestation action).
- Also pins `actions/github-script` to a commit SHA in this file while touching that step (overlaps slightly with #3702).

## Why this, and not npm provenance
`npm publish --provenance` attaches provenance to the **npm registry** package, not to the **GitHub Release** assets. OpenSSF Scorecard's Signed-Releases check only looks at GitHub Release asset filenames (`*.intoto.jsonl` for full credit), so npm provenance alone wouldn't move that score. This does both jobs conceptually but is scoped to what Scorecard actually checks: a release-attached provenance file.

## Verification
Anyone can verify a downloaded archive against this attestation with:
```
gh attestation verify jspsych.zip --owner jspsych
```

## Test plan
- [ ] Confirm the `release` workflow still runs end-to-end on a real changeset release (this can't be fully exercised from a PR, since `changesets/action` only creates/publishes releases on push to `main`).
- [ ] After the next real release, confirm `jspsych.zip.intoto.jsonl` is attached and `gh attestation verify` succeeds against the published `jspsych.zip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)