### PR TITLE
Increase default button and input sizing

### DIFF
--- a/.changeset/touch-target-defaults.md
+++ b/.changeset/touch-target-defaults.md
@@ -1,0 +1,7 @@
+---
+"jspsych": major
+---
+
+Increased the default size of buttons and text inputs in `jspsych.css`. `.jspsych-btn` now uses a 16px font and 12px/16px padding, computing to roughly 48px tall where it previously computed to roughly 38px. This clears the 44px minimum target size given by WCAG 2.5.5 and the Apple Human Interface Guidelines on every device, without a separate rule for touch pointers. Text inputs are raised from 14px to 16px for the same reason, and because iOS Safari zooms the viewport when a field below 16px receives focus.
+
+This is a breaking change: it alters the rendered appearance of every existing experiment that uses `jspsych.css`. Because button size can affect motor response times, experiments partway through data collection should not upgrade. Experiments that need the previous sizing can restore it by overriding `.jspsych-btn` and `.jspsych-display-element input[type="text"]`; see the v9 migration guide.

--- a/docs/overview/style.md
+++ b/docs/overview/style.md
@@ -241,6 +241,22 @@ const trial_procedure = {
 
 See the "css-classes-parameter.html" file in jsPsych's examples subfolder for more explanation and examples.
 
+## Default sizing of buttons and inputs
+
+`jspsych.css` sizes buttons and text inputs to be comfortable to tap as well as click, so experiments work on phones and tablets without additional styling:
+
+* Buttons (`.jspsych-btn`) compute to roughly 48px tall, clearing the 44px minimum target size recommended by [WCAG 2.5.5](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html) and the Apple Human Interface Guidelines.
+* Text inputs use a 16px font. Below that size, iOS Safari zooms the viewport when the field receives focus, which leaves the participant looking at a partial view of the trial.
+
+These are ordinary defaults, so you can override them like any other rule:
+
+```css
+.jspsych-btn {
+  padding: 8px 12px;
+  font-size: 14px;
+}
+```
+
 ## Tips for working with CSS
 
 Your browser's developer tools contain very useful features for exploring and debugging your experiment's style and formatting. Open your browser's developer tools and click on the Element Inspector button or go to the Elements tab. Once you have selected an element on the page, you can see all of the information that can be used to select it, including:

--- a/docs/support/migration-v9.md
+++ b/docs/support/migration-v9.md
@@ -1,0 +1,32 @@
+# Migrating an experiment to v9.x
+
+This guide is aimed at upgrades from version 8.x to 9.x.
+If you are using version 7.x or earlier, please follow the [migration guide for v8.x](./migration-v8.md) before trying to upgrade to v9.x.
+
+## Default sizing of buttons and text inputs
+
+`jspsych.css` now renders buttons and text inputs larger by default.
+
+`.jspsych-btn` uses a 16px font with 12px/16px padding, computing to roughly 48px tall. In version 8.x it used a 14px font with 8px/12px padding, computing to roughly 38px. The new size clears the 44px minimum target size recommended by [WCAG 2.5.5](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html) and the Apple Human Interface Guidelines, which makes experiments usable on phones and tablets without additional styling.
+
+Text inputs in the display element move from a 14px to a 16px font. Below 16px, iOS Safari zooms the viewport when a field receives focus, leaving the participant on a partial view of the trial.
+
+Both changes apply on all devices, not only touch devices.
+
+!!! warning "Consider this before upgrading mid-study"
+    Button size can influence how quickly participants respond. If you are partway through data collection, upgrading will change the motor demands of your task between participants. Finish the study on version 8.x, or restore the previous sizing as shown below.
+
+If you want the version 8.x appearance, add these rules to your own stylesheet, loaded after `jspsych.css`:
+
+```css
+.jspsych-btn {
+  padding: 8px 12px;
+  font-size: 14px;
+}
+
+.jspsych-display-element input[type="text"] {
+  font-size: 14px;
+}
+```
+
+Note that reverting the text input size reintroduces the iOS zoom-on-focus behavior described above.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
   - 'Getting Help': 'support/support.md'
   - 'Migrating from 6.x to 7.x': 'support/migration-v7.md'
   - 'Migrating from 7.x to 8.x': 'support/migration-v8.md'
+  - 'Migrating from 8.x to 9.x': 'support/migration-v9.md'
 - About:
   - 'About jsPsych': 'about/about.md'
   - 'License': 'about/license.md'

--- a/packages/jspsych/src/index.scss
+++ b/packages/jspsych/src/index.scss
@@ -52,9 +52,12 @@
 
 /* Form elements like input fields and buttons */
 
+/* 16px rather than 14px: iOS Safari zooms the viewport when a text field below
+ * that size receives focus, leaving the participant on a partial view of the
+ * trial. */
 .jspsych-display-element input[type="text"] {
   font-family: "Open Sans", "Arial", sans-serif;
-  font-size: 14px;
+  font-size: 16px;
 }
 
 /* Buttons and Button Groups */
@@ -72,11 +75,15 @@
   margin-left: auto;
 }
 
+/* Sized so that the button clears a 44px minimum target — the figure given by
+ * WCAG 2.5.5 and the Apple Human Interface Guidelines — without needing a
+ * separate rule for touch devices. 16px text at 1.4 line-height plus 12px of
+ * vertical padding and the border computes to roughly 48px. */
 .jspsych-btn {
   display: inline-block;
-  padding: 8px 12px;
+  padding: 12px 16px;
   margin: 0.75em;
-  font-size: 14px;
+  font-size: 16px;
   font-weight: 400;
   font-family: "Open Sans", "Arial", sans-serif;
   cursor: pointer;


### PR DESCRIPTION
## Summary

`.jspsych-btn` computed to roughly 38px tall — 14px text at a 1.4 line-height, 8px of vertical padding, and a 1px border. That is below the 44px minimum target size given by [WCAG 2.5.5](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html) and the Apple Human Interface Guidelines, which makes experiments awkward to use on phones and tablets without custom CSS.

This raises the font to 16px and the padding to 12px/16px, bringing the button to roughly 48px on **every** device. Doing it in the base rule rather than under `@media (pointer: coarse)` means there is no separate touch rule to maintain, and mouse users get a more comfortable target too.

Text inputs move from 14px to 16px for the same reason, and because iOS Safari zooms the viewport when a field below 16px receives focus, leaving the participant on a partial view of the trial.

## Breaking change

This alters the rendered appearance of every existing experiment that uses `jspsych.css`, so it is marked `major` and targeted at 9.0.

The reason to treat it as breaking rather than cosmetic is specific to this project: button size can influence how quickly participants respond. A lab that upgrades partway through data collection would get a silent change in the motor demands of its task between participants. `docs/support/migration-v9.md` says so explicitly and shows how to restore the previous sizing.

## Changes

- `packages/jspsych/src/index.scss` — the two rules, each with a comment explaining the figure
- `docs/support/migration-v9.md` — new; this is the first breaking change queued for 9.0, and v7 and v8 both have migration guides
- `mkdocs.yml` — nav entry for the new guide
- `docs/overview/style.md` — documents the defaults and how to override them
- `.changeset/touch-target-defaults.md` — `major`

## Notes for review

- The migration guide is new scaffolding. If you would rather it be written when 9.0 is actually being assembled, it can come out and the changeset alone can carry the note.
- I did not build the mkdocs site, so the nav entry is unverified beyond matching its neighbours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)